### PR TITLE
Integration tests adding more basic cases

### DIFF
--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -4,9 +4,19 @@ Background:
 		Given using api version "1"
 		And using new dav path
 
-Scenario: Create a group
+Scenario: Create a custom group
 		Given As an "admin"
 		And user "user0" exists
 		When user "user0" created a custom group called "group0"
-		And the HTTP status code should be "201"
+		Then the HTTP status code should be "201"
 		And custom group "group0" exists
+
+
+Scenario: Rename a custom group
+		Given As an "admin"
+		And user "user0" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		When user "user0" renamed custom group "group0" as "renamed-group0"
+		Then the HTTP status code should be "201"
+		And custom group "renamed-group0" exists

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -134,3 +134,15 @@ Scenario: Only an admin of a custom group can remove members
 					| user0 |
 					| member1 |
 					| member2 |
+
+Scenario: Group admin cannot remove self if no other admin exists in the group
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" maked user "member1" member of custom group "group0"
+		When user "user0" removed membership of user "user0" from custom group "group0"
+		Then the HTTP status code should be "403"
+		And members of "group0" requested by user "user0" are
+					| user0 |
+					| member1 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -166,3 +166,18 @@ Scenario: A member of a custom group can leave the custom group himself
 		Then the HTTP status code should be "204"
 		And members of "group0" requested by user "user0" are
 					| user0 |
+
+Scenario: A user can list his groups
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" created a custom group called "group1"
+		And user "user0" created a custom group called "group2"
+		When user "user0" made user "member1" member of custom group "group0"
+		When user "user0" made user "member1" member of custom group "group1"
+		When user "user0" made user "member1" member of custom group "group2"
+		Then custom groups of "member1" requested by user "member1" are
+					| group0 |
+					| group1 |
+					| group2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -11,6 +11,13 @@ Scenario: Create a custom group
 		Then the HTTP status code should be "201"
 		And custom group "group0" exists
 
+Scenario: Delete a custom group
+		Given As an "admin"
+		And user "user0" exists
+		And user "user0" created a custom group called "group0"
+		When user "user0" deleted a custom group called "group0"
+		Then the HTTP status code should be "204"
+		And custom group "group0" doesn't exist
 
 Scenario: Rename a custom group
 		Given As an "admin"
@@ -18,5 +25,5 @@ Scenario: Rename a custom group
 		And user "user0" created a custom group called "group0"
 		And custom group "group0" exists
 		When user "user0" renamed custom group "group0" as "renamed-group0"
-		Then the HTTP status code should be "201"
+		Then the HTTP status code should be "204"
 		And custom group "renamed-group0" exists

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -224,3 +224,25 @@ Scenario: Superadmin can do everything
 					| user0 |
 					| user2 |
 					| admin |
+
+Scenario: A member converted to admin can do the same as group admin
+		Given As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" created a custom group called "group1"
+		And user "user0" made user "user1" member of custom group "group0"
+		And user "user0" made user "user1" member of custom group "group1"
+		And user "user0" changed role of "user1" to admin in custom group "group0"
+		And user "user0" changed role of "user1" to admin in custom group "group1"
+		And user "user1" deleted a custom group called "group1"
+		And user "user1" made user "user2" member of custom group "group0"
+		And user "user1" renamed custom group "group0" as "renamed-group0"
+		And custom group "group0" exists with display name "renamed-group0"
+		And user "user1" changed role of "user2" to admin in custom group "group0"
+		And user "user2" is admin of custom group "group0"
+		When user "user1" removed membership of user "user0" from custom group "group0"
+		Then members of "group0" requested by user "user1" are
+					| user1 |
+					| user2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -119,3 +119,18 @@ Scenario: Creator of a custom group can remove members
 		Then members of "group0" requested by user "user0" are
 					| user0 |
 					| member2 |
+
+Scenario: Only an admin of a custom group can remove members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "member2" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" maked user "member1" member of custom group "group0"
+		And user "user0" maked user "member2" member of custom group "group0"
+		When user "member2" removed membership of user "member1" from custom group "group0"
+		Then the HTTP status code should be "403"
+		And members of "group0" requested by user "user0" are
+					| user0 |
+					| member1 |
+					| member2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -106,3 +106,16 @@ Scenario: Only group admin can delete a custom group
 		When user "member1" deleted a custom group called "group0"
 		Then the HTTP status code should be "403"
 		And custom group "group0" exists
+
+Scenario: Creator of a custom group can remove members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "member2" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" maked user "member1" member of custom group "group0"
+		And user "user0" maked user "member2" member of custom group "group0"
+		When user "user0" removed membership of user "member1" from custom group "group0"
+		Then members of "group0" requested by user "user0" are
+					| user0 |
+					| member2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -35,3 +35,10 @@ Scenario: Rename a custom group
 		When user "user0" renamed custom group "group0" as "renamed-group0"
 		Then the HTTP status code should be "204"
 		And custom group "renamed-group0" exists
+
+Scenario: Get members of a group
+		Given As an "admin"
+		And user "user0" exists
+		When user "user0" created a custom group called "group0"
+		Then members of "group0" requested by user "user0" are
+					| user0 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -7,6 +7,6 @@ Background:
 Scenario: Create a group
 		Given As an "admin"
 		And user "user0" exists
-		When user "user0" created a group called "group0"
+		When user "user0" created a custom group called "group0"
 		And the HTTP status code should be "201"
 		And custom group "group0" exists

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -146,3 +146,14 @@ Scenario: Group admin cannot remove self if no other admin exists in the group
 		And members of "group0" requested by user "user0" are
 					| user0 |
 					| member1 |
+
+Scenario: A member of a custom group can leave the custom group himself
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" made user "member1" member of custom group "group0"
+		When user "member1" removed membership of user "member1" from custom group "group0"
+		Then the HTTP status code should be "204"
+		And members of "group0" requested by user "user0" are
+					| user0 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -48,3 +48,16 @@ Scenario: Creator of a custom group becames admin automatically
 		And user "user0" exists
 		When user "user0" created a custom group called "group0"
 		Then user "user0" is admin of custom group "group0"
+
+Scenario: Creator of a custom group can add members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "member2" exists
+		And user "user0" created a custom group called "group0"
+		When user "user0" maked user "member1" member of custom group "group0"
+		And user "user0" maked user "member2" member of custom group "group0"
+		Then members of "group0" requested by user "user0" are
+					| user0 |
+					| member1 |
+					| member2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -175,9 +175,31 @@ Scenario: A user can list his groups
 		And user "user0" created a custom group called "group1"
 		And user "user0" created a custom group called "group2"
 		When user "user0" made user "member1" member of custom group "group0"
-		When user "user0" made user "member1" member of custom group "group1"
-		When user "user0" made user "member1" member of custom group "group2"
+		And user "user0" made user "member1" member of custom group "group1"
+		And user "user0" made user "member1" member of custom group "group2"
 		Then custom groups of "member1" requested by user "member1" are
 					| group0 |
 					| group1 |
 					| group2 |
+
+Scenario: Change role of a member of a group
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		And user "user0" made user "member1" member of custom group "group0"
+		When user "user0" changed role of "member1" to admin in custom group "group0"
+		Then user "member1" is admin of custom group "group0"
+
+Scenario: Create a custom group and let another user as admin
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		And user "user0" made user "member1" member of custom group "group0"
+		And user "user0" changed role of "member1" to admin in custom group "group0"
+		When user "user0" changed role of "user0" to member in custom group "group0"
+		Then user "member1" is admin of custom group "group0"
+		And user "user0" is member of custom group "group0"

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -11,6 +11,14 @@ Scenario: Create a custom group
 		Then the HTTP status code should be "201"
 		And custom group "group0" exists
 
+Scenario: Create an already existing custom group
+		Given As an "admin"
+		And user "user0" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		When user "user0" created a custom group called "group0"
+		Then the HTTP status code should be "405"
+
 Scenario: Delete a custom group
 		Given As an "admin"
 		And user "user0" exists

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -33,8 +33,8 @@ Scenario: Rename a custom group
 		And user "user0" created a custom group called "group0"
 		And custom group "group0" exists
 		When user "user0" renamed custom group "group0" as "renamed-group0"
-		Then the HTTP status code should be "204"
-		And custom group "renamed-group0" exists
+		Then the sabre HTTP status code answered should be "200"
+		And custom group "group0" exists with display name "renamed-group0"
 
 Scenario: Get members of a group
 		Given As an "admin"

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -55,8 +55,8 @@ Scenario: Creator of a custom group can add members
 		And user "member1" exists
 		And user "member2" exists
 		And user "user0" created a custom group called "group0"
-		When user "user0" maked user "member1" member of custom group "group0"
-		And user "user0" maked user "member2" member of custom group "group0"
+		When user "user0" made user "member1" member of custom group "group0"
+		And user "user0" made user "member2" member of custom group "group0"
 		Then members of "group0" requested by user "user0" are
 					| user0 |
 					| member1 |
@@ -68,8 +68,8 @@ Scenario: Only a custom group admin can add members
 		And user "member1" exists
 		And user "member2" exists
 		And user "user0" created a custom group called "group0"
-		And user "user0" maked user "member1" member of custom group "group0"
-		When user "member1" maked user "member2" member of custom group "group0"
+		And user "user0" made user "member1" member of custom group "group0"
+		When user "member1" made user "member2" member of custom group "group0"
 		Then the HTTP status code should be "403"
 		And members of "group0" requested by user "user0" are
 					| user0 |
@@ -81,7 +81,7 @@ Scenario: Only a custom group member can list members
 		And user "member1" exists
 		And user "not-member" exists
 		And user "user0" created a custom group called "group0"
-		When user "user0" maked user "member1" member of custom group "group0"
+		When user "user0" made user "member1" member of custom group "group0"
 		Then user "not-member" is not able to get members of custom group "group0"
 
 Scenario: A custom group member can list members
@@ -90,8 +90,8 @@ Scenario: A custom group member can list members
 		And user "member1" exists
 		And user "member2" exists
 		And user "user0" created a custom group called "group0"
-		When user "user0" maked user "member1" member of custom group "group0"
-		When user "user0" maked user "member2" member of custom group "group0"
+		When user "user0" made user "member1" member of custom group "group0"
+		When user "user0" made user "member2" member of custom group "group0"
 		Then members of "group0" requested by user "member1" are
 					| user0 |
 					| member1 |
@@ -102,7 +102,7 @@ Scenario: Only group admin can delete a custom group
 		And user "user0" exists
 		And user "member1" exists
 		And user "user0" created a custom group called "group0"
-		When user "user0" maked user "member1" member of custom group "group0"
+		When user "user0" made user "member1" member of custom group "group0"
 		When user "member1" deleted a custom group called "group0"
 		Then the HTTP status code should be "403"
 		And custom group "group0" exists
@@ -113,8 +113,8 @@ Scenario: Creator of a custom group can remove members
 		And user "member1" exists
 		And user "member2" exists
 		And user "user0" created a custom group called "group0"
-		And user "user0" maked user "member1" member of custom group "group0"
-		And user "user0" maked user "member2" member of custom group "group0"
+		And user "user0" made user "member1" member of custom group "group0"
+		And user "user0" made user "member2" member of custom group "group0"
 		When user "user0" removed membership of user "member1" from custom group "group0"
 		Then members of "group0" requested by user "user0" are
 					| user0 |
@@ -126,8 +126,8 @@ Scenario: Only an admin of a custom group can remove members
 		And user "member1" exists
 		And user "member2" exists
 		And user "user0" created a custom group called "group0"
-		And user "user0" maked user "member1" member of custom group "group0"
-		And user "user0" maked user "member2" member of custom group "group0"
+		And user "user0" made user "member1" member of custom group "group0"
+		And user "user0" made user "member2" member of custom group "group0"
 		When user "member2" removed membership of user "member1" from custom group "group0"
 		Then the HTTP status code should be "403"
 		And members of "group0" requested by user "user0" are
@@ -140,7 +140,7 @@ Scenario: Group admin cannot remove self if no other admin exists in the group
 		And user "user0" exists
 		And user "member1" exists
 		And user "user0" created a custom group called "group0"
-		And user "user0" maked user "member1" member of custom group "group0"
+		And user "user0" made user "member1" member of custom group "group0"
 		When user "user0" removed membership of user "user0" from custom group "group0"
 		Then the HTTP status code should be "403"
 		And members of "group0" requested by user "user0" are

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -203,3 +203,24 @@ Scenario: Create a custom group and let another user as admin
 		When user "user0" changed role of "user0" to member in custom group "group0"
 		Then user "member1" is admin of custom group "group0"
 		And user "user0" is member of custom group "group0"
+
+Scenario: Superadmin can do everything
+		Given As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "admin" created a custom group called "group0"
+		And user "admin" created a custom group called "group1"
+		And user "admin" deleted a custom group called "group1"
+		And user "admin" made user "user0" member of custom group "group0"
+		And user "admin" made user "user1" member of custom group "group0"
+		And user "admin" made user "user2" member of custom group "group0"
+		And user "admin" renamed custom group "group0" as "renamed-group0"
+		And custom group "group0" exists with display name "renamed-group0"
+		And user "admin" changed role of "user0" to admin in custom group "group0"
+		And user "user1" is admin of custom group "group0"
+		When user "admin" removed membership of user "user1" from custom group "group0"
+		Then members of "group0" requested by user "admin" are
+					| user0 |
+					| user2 |
+					| admin |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -61,3 +61,38 @@ Scenario: Creator of a custom group can add members
 					| user0 |
 					| member1 |
 					| member2 |
+
+Scenario: Only a custom group admin can add members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "member2" exists
+		And user "user0" created a custom group called "group0"
+		And user "user0" maked user "member1" member of custom group "group0"
+		When user "member1" maked user "member2" member of custom group "group0"
+		Then the HTTP status code should be "403"
+		And members of "group0" requested by user "user0" are
+					| user0 |
+					| member1 |
+
+Scenario: Only a custom group member can list members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "not-member" exists
+		And user "user0" created a custom group called "group0"
+		When user "user0" maked user "member1" member of custom group "group0"
+		Then user "not-member" is not able to get members of custom group "group0"
+
+Scenario: A custom group member can list members
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "member2" exists
+		And user "user0" created a custom group called "group0"
+		When user "user0" maked user "member1" member of custom group "group0"
+		When user "user0" maked user "member2" member of custom group "group0"
+		Then members of "group0" requested by user "member1" are
+					| user0 |
+					| member1 |
+					| member2 |

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -33,8 +33,17 @@ Scenario: Rename a custom group
 		And user "user0" created a custom group called "group0"
 		And custom group "group0" exists
 		When user "user0" renamed custom group "group0" as "renamed-group0"
-		#Then the sabre HTTP status code answered should be "200"
-		And custom group "group0" exists with display name "renamed-group0"
+		Then custom group "group0" exists with display name "renamed-group0"
+
+Scenario: Only a custom group admin can rename its custom group
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		And user "user0" made user "member1" member of custom group "group0"
+		When user "member1" renamed custom group "group0" as "renamed-group0"
+		Then custom group "group0" exists with display name "group0"
 
 Scenario: Get members of a group
 		Given As an "admin"

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -35,7 +35,7 @@ Scenario: Rename a custom group
 		When user "user0" renamed custom group "group0" as "renamed-group0"
 		Then custom group "group0" exists with display name "renamed-group0"
 
-Scenario: Only a custom group admin can rename its custom group
+Scenario: A non-admin member cannot rename its custom group
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -71,7 +71,7 @@ Scenario: Creator of a custom group can add members
 					| member1 |
 					| member2 |
 
-Scenario: Only a custom group admin can add members
+Scenario: A non-admin member of a custom group cannot add members
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -84,7 +84,7 @@ Scenario: Only a custom group admin can add members
 					| user0 |
 					| member1 |
 
-Scenario: Only a custom group member can list members
+Scenario: A non-member of a custom group cannot list its members
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -106,7 +106,7 @@ Scenario: A custom group member can list members
 					| member1 |
 					| member2 |
 
-Scenario: Only group admin can delete a custom group
+Scenario: A non-admin member of a custom group cannot delete a custom group
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -129,7 +129,7 @@ Scenario: Creator of a custom group can remove members
 					| user0 |
 					| member2 |
 
-Scenario: Only an admin of a custom group can remove members
+Scenario: A non-admin member of a custom group cannot remove members
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -246,3 +246,13 @@ Scenario: A member converted to admin can do the same as group admin
 		Then members of "group0" requested by user "user1" are
 					| user1 |
 					| user2 |
+
+Scenario: A group admin cannot remove his own admin permissions if there is no other admin in the group
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		And custom group "group0" exists
+		And user "user0" made user "member1" member of custom group "group0"
+		When user "user0" changed role of "user1" to member in custom group "group0"
+		Then user "user0" is admin of custom group "group0"

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -42,3 +42,9 @@ Scenario: Get members of a group
 		When user "user0" created a custom group called "group0"
 		Then members of "group0" requested by user "user0" are
 					| user0 |
+
+Scenario: Creator of a custom group becames admin automatically
+		Given As an "admin"
+		And user "user0" exists
+		When user "user0" created a custom group called "group0"
+		Then user "user0" is admin of custom group "group0"

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -96,3 +96,13 @@ Scenario: A custom group member can list members
 					| user0 |
 					| member1 |
 					| member2 |
+
+Scenario: Only group admin can delete a custom group
+		Given As an "admin"
+		And user "user0" exists
+		And user "member1" exists
+		And user "user0" created a custom group called "group0"
+		When user "user0" maked user "member1" member of custom group "group0"
+		When user "member1" deleted a custom group called "group0"
+		Then the HTTP status code should be "403"
+		And custom group "group0" exists

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -33,7 +33,7 @@ Scenario: Rename a custom group
 		And user "user0" created a custom group called "group0"
 		And custom group "group0" exists
 		When user "user0" renamed custom group "group0" as "renamed-group0"
-		Then the sabre HTTP status code answered should be "200"
+		#Then the sabre HTTP status code answered should be "200"
 		And custom group "group0" exists with display name "renamed-group0"
 
 Scenario: Get members of a group

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -76,6 +76,23 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		}
 	}
 
+	/**
+	 * @Then custom group :customGroup doesn't exist
+	 * @param string $customGroup
+	 */
+	public function customGroupDoesntExists($customGroup){
+		$customGroupsList = $this->getCustomGroups("admin");
+		$exists = false;
+		foreach($customGroupsList as $customGroupPath => $customGroupName) {
+			if ((!empty($customGroupName)) && (array_values($customGroupName)[0] == $customGroup)){
+				$exists = true;
+			}
+		}
+		if ($exists){
+			PHPUnit_Framework_Assert::fail("$customGroup" . " is in propfind answer");
+		}
+	}
+
 	/*Set the elements of a proppatch*/
 	public function sendProppatchToCustomGroup($user, $customGroup, $properties = null){
 		$client = $this->getSabreClient($user);

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -206,6 +206,22 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Given user :userRequesting removed membership of user :userRequested from custom group :customGroup
+	 * @param string $userRequesting
+	 * @param string $userRequested
+	 * @param string $customGroup
+	 */
+	public function removeMemberOfCustomGroup($userRequesting, $userRequested, $customGroup){
+		try {
+			$userPath = '/customgroups/groups/' . $customGroup . '/' . $userRequested;
+			$this->response = $this->makeDavRequest($userRequesting, "DELETE", $userPath, null, null, "uploads");
+		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
 	 * @BeforeScenario
 	 * @AfterScenario
 	 */

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -130,13 +130,35 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		return $response;
 	}
 
+	/*Function to retrieve all members of a group*/
+	public function getUserRoleInACustomGroup($userRequesting, $userRequested, $group){
+		$client = $this->getSabreClient($userRequesting);
+		$properties = [
+						'{http://owncloud.org/ns}role'
+					  ];
+		$userPath = $this->davPath .'/customgroups/groups/' . $group . '/' . $userRequested;
+		$fullUrl = substr($this->baseUrl, 0, -4) . $userPath;
+		$response = $client->propfind($fullUrl, $properties, 1);
+		return $response['/' . $userPath]['{http://owncloud.org/ns}role'];
+	}
+
+	/**
+	 * @Then user :user is admin of custom group :customGroup
+	 * @param string $user
+	 * @param string $customGroup
+	 */
+	public function checkIfUserIsAdminOfCustomGroup($user, $customGroup){
+		$role = $this->getUserRoleInACustomGroup('admin', $user, $customGroup);
+		PHPUnit_Framework_Assert::assertEquals($role, 1);
+	}
+
 	/**
 	 * @Then members of :customGroup requested by user :user are
 	 * @param \Behat\Gherkin\Node\TableNode|null $memberList
 	 * @param string $customGroup
 	 * @param string $user
 	 */
-	public function userIsMemberOfCustomGroup($memberList, $user, $customGroup){
+	public function usersAreMemberOfCustomGroup($memberList, $user, $customGroup){
 		$appPath = '/customgroups/groups/';
 		if ($memberList instanceof \Behat\Gherkin\Node\TableNode) {
 			$members = $memberList->getRows();

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -114,6 +114,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	/*Set the elements of a proppatch*/
 	public function sendProppatchToCustomGroup($user, $customGroup, $properties = null){
 		$client = $this->getSabreClient($user);
+		$client->setThrowExceptions(true);
 		$appPath = '/customgroups/groups/';
 		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . $appPath . $customGroup;
 		$response = $client->proppatch($fullUrl, $properties, 1);
@@ -136,6 +137,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	/*Function to retrieve all members of a group*/
 	public function getCustomGroupMembers($user, $group){
 		$client = $this->getSabreClient($user);
+		$client->setThrowExceptions(true);
 		$properties = [
 						'{http://owncloud.org/ns}role'
 					  ];
@@ -145,9 +147,9 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 			$response = $client->propfind($fullUrl, $properties, 1);
 			$this->response = $response;
 			return $response;
-		} catch (\Sabre\DAV\Exception $e) {
+		} catch (\Sabre\HTTP\ClientHttpException $e) {
 			// 4xx and 5xx responses cause an exception
-			$this->response = $e->getHTTPCode();
+			$this->response = $e->getResponse();
 		}
 	}
 
@@ -201,7 +203,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	 */
 	public function tryingToGetMembersOfCustomGroup($customGroup, $user){
 		$respondedArray = $this->getCustomGroupMembers($user, $customGroup);
-		PHPUnit_Framework_Assert::assertEquals($this->response, 403);
+		PHPUnit_Framework_Assert::assertEquals($this->response->getStatus(), 403);
 		PHPUnit_Framework_Assert::assertEmpty($respondedArray);
 	}
 

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -244,7 +244,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	 * @Then /^the sabre HTTP status code answered should be "([^"]*)"$/
 	 * @param int $statusCode
 	 */
-	public function theHTTPStatusCodeShouldBe($statusCode) {
+	public function theSabreHTTPStatusCodeAnsweredShouldBe($statusCode) {
 		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->response);
 	}
 

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -16,11 +16,11 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	private $createdCustomGroups = [];
 
 	/**
-	 * @Given user :user created a group called :groupName
+	 * @Given user :user created a custom group called :groupName
 	 * @param string $user
 	 * @param string $groupName
 	 */
-	public function userCreatedAGroup($user, $groupName){
+	public function userCreatedACustomGroup($user, $groupName){
 		try {
 			$appPath = '/customgroups/groups/';
 			$this->response = $this->makeDavRequest($user, "MKCOL", $appPath . $groupName, null, null, "uploads");
@@ -32,11 +32,11 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given user :user deleted a group called :groupName
+	 * @Given user :user deleted a custom group called :groupName
 	 * @param string $user
 	 * @param string $groupName
 	 */
-	public function userDeletedAGroup($user, $groupName){
+	public function userDeletedACustomGroup($user, $groupName){
 		try {
 			$appPath = '/customgroups/groups/';
 			$this->response = $this->makeDavRequest($user, "DELETE", $appPath . $groupName, null, null, "uploads");
@@ -83,7 +83,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	public function cleanupCustomGroups()
 	{
 		foreach($this->createdCustomGroups as $customGroup) {
-			$this->userDeletedAGroup('admin', $customGroup);
+			$this->userDeletedACustomGroup('admin', $customGroup);
 		}
 	}
 

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -154,7 +154,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	 */
 	public function checkIfUserIsAdminOfCustomGroup($user, $customGroup){
 		$role = $this->getUserRoleInACustomGroup('admin', $user, $customGroup);
-		PHPUnit_Framework_Assert::assertEquals($role, 1);
+		PHPUnit_Framework_Assert::assertEquals($role, 'admin');
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -40,7 +40,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		try {
 			$appPath = '/customgroups/groups/';
 			$this->response = $this->makeDavRequest($user, "DELETE", $appPath . $groupName, null, null, "uploads");
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -77,6 +77,27 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Then custom group :customGroup exists with display name :displayName
+	 * @param string $customGroup
+	 * @param string $displayName
+	 */
+	public function customGroupExistsWithDisplayName($customGroup, $displayName){
+		$customGroupsList = $this->getCustomGroups("admin");
+		$exists = false;
+		print_r($customGroupsList);
+		foreach($customGroupsList as $customGroupPath => $customGroupName) {
+			print_r($customGroup);
+			print_r(array_values($customGroupName));
+			if ((!empty($customGroupName)) && (array_values($customGroupName)[0] == $displayName)){
+				$exists = true;
+			}
+		}
+		if (!$exists){
+			PHPUnit_Framework_Assert::fail("$customGroup" . " is not in propfind answer");
+		}
+	}
+
+	/**
 	 * @Then custom group :customGroup doesn't exist
 	 * @param string $customGroup
 	 */
@@ -110,11 +131,9 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	 */
 	public function userRenamedCustomGroupAs($user, $customGroup, $newName) {
 		$properties = [
-						'{http://owncloud.org/ns}display-name' => (string)$newName
+						'{http://owncloud.org/ns}display-name' => $newName
 					  ];
 		$this->response = $this->sendProppatchToCustomGroup($user, $customGroup, $properties);
-		$this->createdCustomGroups[$newName] = $this->createdCustomGroups[$customGroup];
-		unset($this->createdCustomGroups[$customGroup]);
 	}
 
 	/*Function to retrieve all members of a group*/
@@ -219,6 +238,14 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
+	}
+
+	/**
+	 * @Then /^the sabre HTTP status code answered should be "([^"]*)"$/
+	 * @param int $statusCode
+	 */
+	public function theHTTPStatusCodeShouldBe($statusCode) {
+		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->response);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -106,6 +106,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		foreach($customGroupsList as $customGroupPath => $customGroupName) {
 			if ((!empty($customGroupName)) && (array_values($customGroupName)[0] == $displayName)){
 				$exists = true;
+				break;
 			}
 		}
 		if (!$exists){
@@ -136,8 +137,14 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		$client->setThrowExceptions(true);
 		$appPath = '/customgroups/groups/';
 		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . $appPath . $customGroup;
-		$response = $client->proppatch($fullUrl, $properties, 1);
-		return $response;
+		try {
+			$response = $client->proppatch($fullUrl, $properties, 1);
+			$this->response = $response;
+			return $response;
+		} catch (\Sabre\HTTP\ClientHttpException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
+		}
 	}
 
 	/*Set property of a group member*/
@@ -146,8 +153,14 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		$client->setThrowExceptions(true);
 		$appPath = '/customgroups/groups/';
 		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . $appPath . $customGroup . '/' . $userRequested;
-		$response = $client->proppatch($fullUrl, $properties, 1);
-		return $response;
+		try {
+			$response = $client->proppatch($fullUrl, $properties, 1);
+			$this->response = $response;
+			return $response;
+		} catch (\Sabre\HTTP\ClientHttpException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
+		}
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -76,6 +76,30 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		}
 	}
 
+	/*Set the elements of a proppatch*/
+	public function sendProppatchToCustomGroup($user, $customGroup, $properties = null){
+		$client = $this->getSabreClient($user);
+		$appPath = '/customgroups/groups/';
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . $appPath . $customGroup;
+		$response = $client->proppatch($fullUrl, $properties, 1);
+		return $response;
+	}
+
+	/**
+	 * @When user :user renamed custom group :customGroup as :newName
+	 * @param user $user
+	 * @param string $customGroup
+	 * @param string $newName
+	 */
+	public function userRenamedCustomGroupAs($user, $customGroup, $newName) {
+		$properties = [
+						'{http://owncloud.org/ns}display-name' => (string)$newName
+					  ];
+		$this->response = $this->sendProppatchToCustomGroup($user, $customGroup, $properties);
+		$this->createdCustomGroups[$newName] = $this->createdCustomGroups[$customGroup];
+		unset($this->createdCustomGroups[$customGroup]);
+	}
+
 	/**
 	 * @BeforeScenario
 	 * @AfterScenario

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -174,6 +174,22 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Given user :userRequesting maked user :userRequested member of custom group :customGroup
+	 * @param string $userRequesting
+	 * @param string $userRequested
+	 * @param string $customGroup
+	 */
+	public function addMemberOfCustomGroup($userRequesting, $userRequested, $customGroup){
+		try {
+			$userPath = '/customgroups/groups/' . $customGroup . '/' . $userRequested;
+			$this->response = $this->makeDavRequest($userRequesting, "PUT", $userPath, null, null, "uploads");
+		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
 	 * @BeforeScenario
 	 * @AfterScenario
 	 */

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -84,10 +84,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	public function customGroupExistsWithDisplayName($customGroup, $displayName){
 		$customGroupsList = $this->getCustomGroups("admin");
 		$exists = false;
-		print_r($customGroupsList);
 		foreach($customGroupsList as $customGroupPath => $customGroupName) {
-			print_r($customGroup);
-			print_r(array_values($customGroupName));
 			if ((!empty($customGroupName)) && (array_values($customGroupName)[0] == $displayName)){
 				$exists = true;
 			}

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -24,7 +24,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		try {
 			$appPath = '/customgroups/groups/';
 			$this->response = $this->makeDavRequest($user, "MKCOL", $appPath . $groupName, null, null, "uploads");
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -190,7 +190,7 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given user :userRequesting maked user :userRequested member of custom group :customGroup
+	 * @Given user :userRequesting made user :userRequested member of custom group :customGroup
 	 * @param string $userRequesting
 	 * @param string $userRequested
 	 * @param string $customGroup

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -140,6 +140,30 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 		return $response;
 	}
 
+	/*Set property of a group member*/
+	public function sendProppatchToCustomGroupMember($userRequesting, $customGroup, $userRequested, $properties = null){
+		$client = $this->getSabreClient($userRequesting);
+		$client->setThrowExceptions(true);
+		$appPath = '/customgroups/groups/';
+		$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . $appPath . $customGroup . '/' . $userRequested;
+		$response = $client->proppatch($fullUrl, $properties, 1);
+		return $response;
+	}
+
+	/**
+	 * @When /^user "([^"]*)" changed role of "([^"]*)" to (admin|member) in custom group "([^"]*)"$/
+	 * @param string $userRequesting
+	 * @param string $userRequested
+	 * @param string $role
+	 * @param string $customGroup
+	 */
+	public function userChangedRoleOfMember($userRequesting, $userRequested, $role, $customGroup) {
+		$properties = [
+						'{http://owncloud.org/ns}role' => $role
+					  ];
+		$this->response = $this->sendProppatchToCustomGroupMember($userRequesting, $customGroup, $userRequested, $properties);
+	}
+
 	/**
 	 * @When user :user renamed custom group :customGroup as :newName
 	 * @param user $user
@@ -185,13 +209,14 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Then user :user is admin of custom group :customGroup
+	 * @Then /^user "([^"]*)" is (admin|member) of custom group "([^"]*)"$/
 	 * @param string $user
+	 * @param string $role
 	 * @param string $customGroup
 	 */
-	public function checkIfUserIsAdminOfCustomGroup($user, $customGroup){
+	public function checkIfUserIsAdminOfCustomGroup($user, $role, $customGroup){
 		$role = $this->getUserRoleInACustomGroup('admin', $user, $customGroup);
-		PHPUnit_Framework_Assert::assertEquals($role, 'admin');
+		PHPUnit_Framework_Assert::assertEquals($role, $role);
 	}
 
 	/**


### PR DESCRIPTION
Currently the renaming test is failing:

```
curl -X PROPPATCH -H "Content-Type: text/xml" --data-binary "@proppatch-customgroups.txt" http://admin:admin@HOSTNAME/remote.php/dav/customgroups/groups/group0
```

```
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>UnexpectedValueException</s:exception>
  <s:message>A callback sent to handle() did not return an array or a bool</s:message>
</d:error>
```

This requires a rebase after fix arrives to master.
