### PR TITLE
Add pagination/search through REPORT

### DIFF
--- a/lib/CustomGroupsBackend.php
+++ b/lib/CustomGroupsBackend.php
@@ -79,7 +79,7 @@ class CustomGroupsBackend implements \OCP\GroupInterface {
 	 * @return array an array of group names
 	 */
 	public function getUserGroups($uid) {
-		$memberInfos = $this->handler->getUserMemberships($uid, null);
+		$memberInfos = $this->handler->getUserMemberships($uid, null, null);
 		return array_map(function ($memberInfo) {
 			return $this->formatGroupId($memberInfo['group_id']);
 		}, $memberInfos);
@@ -96,7 +96,7 @@ class CustomGroupsBackend implements \OCP\GroupInterface {
 	 * @return array an array of group names
 	 */
 	public function getGroups($search = '', $limit = -1, $offset = 0) {
-		$groups = $this->handler->searchGroups($search, $limit, $offset);
+		$groups = $this->handler->searchGroups(new Search($search, $offset, $limit));
 		return array_map(function ($groupInfo) {
 			return $this->formatGroupId($groupInfo['group_id']);
 		}, $groups);

--- a/lib/CustomGroupsBackend.php
+++ b/lib/CustomGroupsBackend.php
@@ -79,7 +79,7 @@ class CustomGroupsBackend implements \OCP\GroupInterface {
 	 * @return array an array of group names
 	 */
 	public function getUserGroups($uid) {
-		$memberInfos = $this->handler->getUserMemberships($uid, null, null);
+		$memberInfos = $this->handler->getUserMemberships($uid, null);
 		return array_map(function ($memberInfo) {
 			return $this->formatGroupId($memberInfo['group_id']);
 		}, $memberInfos);

--- a/lib/CustomGroupsDatabaseHandler.php
+++ b/lib/CustomGroupsDatabaseHandler.php
@@ -23,6 +23,7 @@ namespace OCA\CustomGroups;
 
 use OCP\IDBConnection;
 use OCP\ILogger;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Database handler for custom groups
@@ -85,10 +86,11 @@ class CustomGroupsDatabaseHandler {
 	 *
 	 * @param string $uid Name of the user
 	 * @param null|int $roleFilter optional role filter
+	 * @param Search $search search
 	 * @return array an array of member info
 	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
 	 */
-	public function getUserMemberships($uid, $roleFilter = null) {
+	public function getUserMemberships($uid, $roleFilter = null, $search = null) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('m.group_id', 'm.user_id', 'm.role', 'g.uri', 'g.display_name')
 			->from('custom_group_member', 'm')
@@ -100,6 +102,8 @@ class CustomGroupsDatabaseHandler {
 		if (!is_null($roleFilter)) {
 			$qb->andWhere($qb->expr()->eq('role', $qb->createNamedParameter($roleFilter)));
 		}
+
+		$this->applySearch($qb, $search, 'display_name');
 
 		$cursor = $qb->execute();
 
@@ -120,30 +124,17 @@ class CustomGroupsDatabaseHandler {
 	 * search string can appear anywhere within the display name
 	 * field.
 	 *
-	 * @param string $search search string
-	 * @param int $limit limit or -1 to disable
-	 * @param int $offset offset
+	 * @param Search $search search
 	 * @return array an array of group info
 	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
 	 */
-	public function searchGroups($search = '', $limit = -1, $offset = 0) {
+	public function searchGroups($search = null) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select(['group_id', 'uri', 'display_name'])
 			->from('custom_group')
 			->orderBy('display_name', 'ASC');
 
-		if ($search !== '') {
-			$likeString = '%' . $this->dbConn->escapeLikeParameter(strtolower($search)) . '%';
-			$qb->where($qb->expr()->like($qb->createFunction('LOWER(`display_name`)'), $qb->createNamedParameter($likeString)));
-		}
-
-		if ($limit > 0) {
-			$qb->setMaxResults($limit);
-		}
-
-		if ($offset !== 0) {
-			$qb->setFirstResult($offset);
-		}
+		$this->applySearch($qb, $search, 'display_name');
 
 		$cursor = $qb->execute();
 		$groups = $cursor->fetchAll();
@@ -200,11 +191,13 @@ class CustomGroupsDatabaseHandler {
 	/**
 	 * Returns the info for all groups.
 	 *
+	 * @param Search $search search
+	 *
 	 * @return array array of group info
 	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
 	 */
-	public function getGroups() {
-		return $this->searchGroups();
+	public function getGroups($search = null) {
+		return $this->searchGroups($search);
 	}
 
 	/**
@@ -324,10 +317,11 @@ class CustomGroupsDatabaseHandler {
 	 * @param int $gid numeric group id
 	 * @param null|bool $roleFilter optional role filter, set to true or false to
 	 * filter by non-admin-only or admin-only
+	 * @param Search $search search
 	 * @return array array of member info
 	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
 	 */
-	public function getGroupMembers($gid, $roleFilter = null) {
+	public function getGroupMembers($gid, $roleFilter = null, $search = null) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select(['user_id', 'group_id', 'role'])
 			->from('custom_group_member')
@@ -337,6 +331,9 @@ class CustomGroupsDatabaseHandler {
 		if (!is_null($roleFilter)) {
 			$qb->andWhere($qb->expr()->eq('role', $qb->createNamedParameter($roleFilter)));
 		}
+
+		// TODO: also by display name
+		$this->applySearch($qb, $search, 'user_id');
 
 		$cursor = $qb->execute();
 
@@ -408,5 +405,31 @@ class CustomGroupsDatabaseHandler {
 			'group_id' => (int)$row['group_id'],
 			'role' => (int)$row['role'],
 		];
+	}
+
+	/**
+	 * Apply search to the given query
+	 *
+	 * @param IQueryBuilder $qb query builder
+	 * @param Search $search search
+	 * @param string $property property to apply search on
+	 * @return IQueryBuilder query builder
+	 */
+	private function applySearch(IQueryBuilder $qb, $search, $property = null) {
+		if ($search !== null) {
+			if ($search->getPattern() !== null && $property !== null) {
+				$likeString = '%' . $this->dbConn->escapeLikeParameter(strtolower($search->getPattern())) . '%';
+				$qb->andWhere($qb->expr()->like($qb->createFunction('LOWER(`' . $property . '`)'), $qb->createNamedParameter($likeString)));
+			}
+
+			if ($search->getLimit() !== null) {
+				$qb->setMaxResults($search->getLimit());
+			}
+
+			if ($search->getOffset() !== null) {
+				$qb->setFirstResult($search->getOffset());
+			}
+		}
+		return $qb;
 	}
 }

--- a/lib/Dav/GroupMembershipCollection.php
+++ b/lib/Dav/GroupMembershipCollection.php
@@ -224,7 +224,7 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 			&& !$this->helper->isUserAdmin($groupId)) {
 			throw new Forbidden("No permission to list members of group \"$groupId\"");
 		}
-		$members = $this->groupsHandler->getGroupMembers($groupId, null, $search);
+		$members = $this->groupsHandler->getGroupMembers($groupId, $search);
 		return array_map(function ($memberInfo) {
 			return $this->createCustomGroupMemberNode($memberInfo);
 		}, $members);

--- a/lib/Dav/GroupMembershipCollection.php
+++ b/lib/Dav/GroupMembershipCollection.php
@@ -28,6 +28,7 @@ use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\PreconditionFailed;
 use OCA\CustomGroups\Dav\Roles;
+use OCA\CustomGroups\Search;
 
 /**
  * Group memberships collection for a given group
@@ -214,12 +215,16 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 	 * @throws Forbidden if the current user has insufficient permissions
 	 */
 	public function getChildren() {
+		return $this->search();
+	}
+
+	public function search(Search $search = null) {
 		$groupId = $this->groupInfo['group_id'];
 		if (!$this->helper->isUserMember($groupId)
 			&& !$this->helper->isUserAdmin($groupId)) {
 			throw new Forbidden("No permission to list members of group \"$groupId\"");
 		}
-		$members = $this->groupsHandler->getGroupMembers($groupId);
+		$members = $this->groupsHandler->getGroupMembers($groupId, null, $search);
 		return array_map(function ($memberInfo) {
 			return $this->createCustomGroupMemberNode($memberInfo);
 		}, $members);

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -128,7 +128,7 @@ class GroupsCollection implements ICollection {
 	 */
 	public function search(Search $search = null) {
 		if ($this->userId !== null) {
-			$allGroups = $this->groupsHandler->getUserMemberships($this->userId, null, $search);
+			$allGroups = $this->groupsHandler->getUserMemberships($this->userId, $search);
 		} else {
 			$allGroups = $this->groupsHandler->getGroups($search);
 		}

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -22,9 +22,11 @@
 namespace OCA\CustomGroups\Dav;
 
 use Sabre\DAV\ICollection;
-use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\MethodNotAllowed;
+
+use OCA\CustomGroups\CustomGroupsDatabaseHandler;
+use OCA\CustomGroups\Search;
 
 /**
  * Collection of custom groups
@@ -116,10 +118,19 @@ class GroupsCollection implements ICollection {
 	 * @return GroupMembershipCollection[] custom group nodes
 	 */
 	public function getChildren() {
+		return $this->search();
+	}
+
+	/**
+	 * Search nodes
+	 *
+	 * @param Search $search search
+	 */
+	public function search(Search $search = null) {
 		if ($this->userId !== null) {
-			$allGroups = $this->groupsHandler->getUserMemberships($this->userId);
+			$allGroups = $this->groupsHandler->getUserMemberships($this->userId, null, $search);
 		} else {
-			$allGroups = $this->groupsHandler->getGroups();
+			$allGroups = $this->groupsHandler->getGroups($search);
 		}
 		return array_map(function ($groupInfo) {
 			return $this->createMembershipsCollection($groupInfo);

--- a/lib/Dav/ReportRequest.php
+++ b/lib/Dav/ReportRequest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups\Dav;
+
+use Sabre\Xml\Element\Base;
+use Sabre\Xml\Element\KeyValue;
+use Sabre\Xml\Reader;
+use Sabre\Xml\XmlDeserializable;
+
+use OCA\CustomGroups\Search;
+use OCP\IDBConnection;
+use OCP\ILogger;
+
+/**
+ * Report request
+ */
+class ReportRequest implements XmlDeserializable {
+
+	/**
+	 * @var string[]
+	 */
+	private $properties;
+
+	/**
+	 * @var Search
+	 */
+	private $search;
+
+	/**
+	 * Constructs a new search
+	 *
+	 * @param string $pattern pattern or null for none
+	 * @param int $offset offset or null for none
+	 * @param int $limit limit or null for none
+	 */
+	public function __construct($properties = null, $search = null) {
+		$this->properties = $properties;
+		$this->search = $search;
+	}
+
+	/**
+	 * Returns the requested properties
+	 *
+	 * @return string[]
+	 */
+	public function getProperties() {
+		return $this->properties;
+	}
+
+	/**
+	 * Returns the search
+	 *
+	 * @return Search search
+	 */
+	public function getSearch() {
+		return $this->search;
+	}
+
+	/**
+	 * @param Reader $reader
+	 * @return mixed
+	 */
+	static function xmlDeserialize(Reader $reader) {
+		$request = new ReportRequest();
+
+		$elems = (array)$reader->parseInnerTree([
+			'{DAV:}prop' => KeyValue::class,
+			'{http://owncloud.org/ns}search' => KeyValue::class,
+		]);
+
+		if (!is_array($elems)) {
+			$elems = [];
+		}
+
+		$search = null;
+		$properties = [];
+
+		foreach ($elems as $elem) {
+			switch ($elem['name']) {
+				case '{http://owncloud.org/ns}search' :
+					$value = $elem['value'];
+					$search = new Search();
+					if (isset($value['{http://owncloud.org/ns}pattern'])) {
+						$search->setPattern($value['{http://owncloud.org/ns}pattern']);
+					}
+					if (isset($value['{http://owncloud.org/ns}limit'])) {
+						$search->setLimit((int)$value['{http://owncloud.org/ns}limit']);
+					}
+					if (isset($value['{http://owncloud.org/ns}offset'])) {
+						$search->setOffset((int)$value['{http://owncloud.org/ns}offset']);
+					}
+					break;
+				case '{DAV:}prop' :
+					$properties = array_keys($elem['value']);
+					break;
+			}
+		}
+
+		return new ReportRequest($properties, $search);
+	}
+}

--- a/lib/Dav/ReportRequest.php
+++ b/lib/Dav/ReportRequest.php
@@ -29,6 +29,7 @@ use Sabre\Xml\XmlDeserializable;
 use OCA\CustomGroups\Search;
 use OCP\IDBConnection;
 use OCP\ILogger;
+use OCA\CustomGroups\Dav\Roles;
 
 /**
  * Report request

--- a/lib/Search.php
+++ b/lib/Search.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups;
+
+use OCP\IDBConnection;
+use OCP\ILogger;
+
+/**
+ * Search criteria
+ */
+class Search {
+
+	/**
+	 * Search pattern
+	 *
+	 * @var string
+	 */
+	private $pattern;
+
+	/**
+	 * Offset
+	 *
+	 * @var int
+	 */
+	private $offset;
+
+	/**
+	 * Limit
+	 *
+	 * @var int
+	 */
+	private $limit;
+
+
+	/**
+	 * Constructs a new search
+	 *
+	 * @param string $pattern pattern or null for none
+	 * @param int $offset offset or null for none
+	 * @param int $limit limit or null for none
+	 */
+	public function __construct($pattern = null, $offset = null, $limit = null) {
+		$this->setPattern($pattern);
+		$this->setOffset($offset);
+		$this->setLimit($limit);
+	}
+
+	/**
+	 * Set search pattern or null for none
+	 *
+	 * @param string pattern pattern
+	 */
+	public function setPattern($pattern) {
+		if ($pattern === '') {
+			$pattern = null;
+		}
+		$this->pattern = $pattern;
+	}
+
+	/**
+	 * Returns the search pattern
+	 *
+	 * @return string
+	 */
+	public function getPattern() {
+		return $this->pattern;
+	}
+
+	/**
+	 * Set offset or null for none
+	 *
+	 * @param int $offset offset
+	 */
+	public function setOffset($offset) {
+		if ($offset <= 0) {
+			$offset = null;
+		}
+		$this->offset = $offset;
+	}
+
+	/**
+	 * Returns the offset
+	 *
+	 * @return int
+	 */
+	public function getOffset() {
+		return $this->offset;
+	}
+
+	/**
+	 * Set limit or null for no limit.
+	 *
+	 * @param int $limit limit
+	 */
+	public function setLimit($limit) {
+		if ($limit <= 0) {
+			$limit = null;
+		}
+		$this->limit = $limit;
+	}
+
+	/**
+	 * Returns the limit
+	 *
+	 * @return int
+	 */
+	public function getLimit() {
+		return $this->limit;
+	}
+}

--- a/lib/Search.php
+++ b/lib/Search.php
@@ -50,6 +50,12 @@ class Search {
 	 */
 	private $limit;
 
+	/**
+	 * Role filter
+	 *
+	 * @var int
+	 */
+	private $roleFilter = null;
 
 	/**
 	 * Constructs a new search
@@ -67,7 +73,7 @@ class Search {
 	/**
 	 * Set search pattern or null for none
 	 *
-	 * @param string pattern pattern
+	 * @param string $pattern pattern
 	 */
 	public function setPattern($pattern) {
 		if ($pattern === '') {
@@ -125,5 +131,26 @@ class Search {
 	 */
 	public function getLimit() {
 		return $this->limit;
+	}
+
+	/**
+	 * Set role filter
+	 *
+	 * @param int $roleFilter role as integer
+	 */
+	public function setRoleFilter($roleFilter) {
+		if ($roleFilter === '') {
+			$roleFilter = null;
+		}
+		$this->roleFilter = $roleFilter;
+	}
+
+	/**
+	 * Returns the role filter
+	 *
+	 * @return int role filter
+	 */
+	public function getRoleFilter() {
+		return $this->roleFilter;
 	}
 }

--- a/tests/unit/CustomGroupsBackendTest.php
+++ b/tests/unit/CustomGroupsBackendTest.php
@@ -24,6 +24,7 @@ use OCP\IDBConnection;
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use OCA\CustomGroups\CustomGroupsBackend;
 use OCP\GroupInterface;
+use OCA\CustomGroups\Search;
 
 /**
  * Class CustomGroupsBackendTest
@@ -70,8 +71,8 @@ class CustomGroupsBackendTest extends \Test\TestCase {
 		$this->handler->expects($this->any())
 			->method('getUserMemberships')
 			->will($this->returnValueMap([
-				['user1', null, [['group_id' => 1], ['group_id' => 2]]],
-				['user2', null, [['group_id' => 1], ['group_id' => 3]]],
+				['user1', null, null, [['group_id' => 1], ['group_id' => 2]]],
+				['user2', null, null, [['group_id' => 1], ['group_id' => 3]]],
 			]));
 
 		$this->assertEquals(
@@ -93,7 +94,7 @@ class CustomGroupsBackendTest extends \Test\TestCase {
 	public function testGetGroups() {
 		$this->handler->expects($this->any())
 			->method('searchGroups')
-			->with('ser', 10, 5)
+			->with(new Search('ser', 5, 10))
 			->will($this->returnValue([
 				['group_id' => 1],
 				['group_id' => 2],

--- a/tests/unit/CustomGroupsBackendTest.php
+++ b/tests/unit/CustomGroupsBackendTest.php
@@ -71,8 +71,8 @@ class CustomGroupsBackendTest extends \Test\TestCase {
 		$this->handler->expects($this->any())
 			->method('getUserMemberships')
 			->will($this->returnValueMap([
-				['user1', null, null, [['group_id' => 1], ['group_id' => 2]]],
-				['user2', null, null, [['group_id' => 1], ['group_id' => 3]]],
+				['user1', null, [['group_id' => 1], ['group_id' => 2]]],
+				['user2', null, [['group_id' => 1], ['group_id' => 3]]],
 			]));
 
 		$this->assertEquals(

--- a/tests/unit/CustomGroupsDatabaseHandlerTest.php
+++ b/tests/unit/CustomGroupsDatabaseHandlerTest.php
@@ -23,6 +23,7 @@ namespace OCA\CustomGroups\Tests\unit;
 use OCP\IDBConnection;
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use OCP\ILogger;
+use OCA\CustomGroups\Search;
 
 /**
  * Class CustomGroupsDatabaseHandlerTest
@@ -97,7 +98,7 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 		$group2Id = $this->handler->createGroup('my_group_2', 'My Group Two');
 		$group3Id = $this->handler->createGroup('my_group_3', 'AA One');
 
-		$results = $this->handler->searchGroups('one');
+		$results = $this->handler->searchGroups(new Search('one'));
 		$this->assertCount(2, $results);
 
 		// results sorted by display_name
@@ -122,7 +123,7 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 			$groupIds[$i] = $this->handler->createGroup('my_group_' . $num, 'My Group ' . $num);
 		}
 
-		$results = $this->handler->searchGroups('Group', 3, 5);
+		$results = $this->handler->searchGroups(new Search('Group', 5, 3));
 		$this->assertCount(3, $results);
 
 		$this->assertEquals($groupIds[5], $results[0]['group_id']);
@@ -130,7 +131,7 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 		$this->assertEquals($groupIds[7], $results[2]['group_id']);
 
 		// search beyond last page
-		$results = $this->handler->searchGroups('Group', 100, 5);
+		$results = $this->handler->searchGroups(new Search('Group', 5, 100));
 		$this->assertCount(25, $results);
 	}
 

--- a/tests/unit/CustomGroupsDatabaseHandlerTest.php
+++ b/tests/unit/CustomGroupsDatabaseHandlerTest.php
@@ -239,8 +239,12 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 		$this->assertTrue($this->handler->addToGroup('user2', $groupId, CustomGroupsDatabaseHandler::ROLE_MEMBER));
 		$this->assertTrue($this->handler->addToGroup('user1', $groupId, CustomGroupsDatabaseHandler::ROLE_ADMIN));
 
-		$adminMembers = $this->handler->getGroupMembers($groupId, CustomGroupsDatabaseHandler::ROLE_ADMIN);
-		$nonAdminMembers = $this->handler->getGroupMembers($groupId, CustomGroupsDatabaseHandler::ROLE_MEMBER);
+		$searchAdmins = new Search();
+		$searchAdmins->setRoleFilter(CustomGroupsDatabaseHandler::ROLE_ADMIN);
+		$searchMembers = new Search();
+		$searchMembers->setRoleFilter(CustomGroupsDatabaseHandler::ROLE_MEMBER);
+		$adminMembers = $this->handler->getGroupMembers($groupId, $searchAdmins);
+		$nonAdminMembers = $this->handler->getGroupMembers($groupId, $searchMembers);
 
 		$this->assertCount(1, $adminMembers);
 		$this->assertCount(1, $nonAdminMembers);
@@ -334,9 +338,14 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 		$this->handler->addToGroup('user1', $groupId, CustomGroupsDatabaseHandler::ROLE_MEMBER);
 		$this->handler->addToGroup('user1', $groupId2, CustomGroupsDatabaseHandler::ROLE_ADMIN);
 
-		$adminGroups = $this->handler->getUserMemberships('user1', CustomGroupsDatabaseHandler::ROLE_ADMIN);
+		$searchAdmins = new Search();
+		$searchAdmins->setRoleFilter(CustomGroupsDatabaseHandler::ROLE_ADMIN);
+		$searchMembers = new Search();
+		$searchMembers->setRoleFilter(CustomGroupsDatabaseHandler::ROLE_MEMBER);
+
+		$adminGroups = $this->handler->getUserMemberships('user1', $searchAdmins);
 		$this->assertCount(1, $adminGroups);
-		$nonAdminGroups = $this->handler->getUserMemberships('user1', CustomGroupsDatabaseHandler::ROLE_MEMBER);
+		$nonAdminGroups = $this->handler->getUserMemberships('user1', $searchMembers);
 		$this->assertCount(1, $nonAdminGroups);
 
 		$this->assertEquals($groupId, $nonAdminGroups[0]['group_id']);

--- a/tests/unit/CustomGroupsPluginTest.php
+++ b/tests/unit/CustomGroupsPluginTest.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups\Tests\unit;
+
+use OCA\CustomGroups\Dav\CustomGroupsPlugin;
+use OCA\CustomGroups\Dav\GroupsCollection;
+use OCA\CustomGroups\Dav\ReportRequest;
+use OCA\CustomGroups\Search;
+use OCA\CustomGroups\Dav\GroupMembershipCollection;
+use OCA\CustomGroups\Dav\MembershipNode;
+
+class CustomGroupsPluginTest extends \Test\TestCase {
+	/** @var \Sabre\DAV\Server|\PHPUnit_Framework_MockObject_MockObject */
+	private $server;
+
+	/** @var \Sabre\DAV\Tree|\PHPUnit_Framework_MockObject_MockObject */
+	private $tree;
+
+	/** @var  \OCP\IUserSession */
+	private $userSession;
+
+	/** @var CustomGroupsPlugin */
+	private $plugin;
+
+	public function setUp() {
+		parent::setUp();
+		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+			->setConstructorArgs([$this->tree])
+			->setMethods(['getRequestUri', 'getBaseUri', 'generateMultiStatus'])
+			->getMock();
+
+		$this->server->expects($this->any())
+			->method('getBaseUri')
+			->will($this->returnValue('http://example.com/owncloud/remote.php/dav'));
+
+		$this->userSession = $this->createMock('\OCP\IUserSession');
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('testuser'));
+		$this->userSession->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($user));
+
+		$this->plugin = new CustomGroupsPlugin(
+			$this->userSession
+		);
+	}
+
+	public function testOnReportInvalidNode() {
+		$path = 'totally/unrelated/13';
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/' . $path)
+			->will($this->returnValue($this->createMock('\Sabre\DAV\INode')));
+
+		$this->server->expects($this->any())
+			->method('getRequestUri')
+			->will($this->returnValue($path));
+		$this->plugin->initialize($this->server);
+
+		$this->assertNull($this->plugin->onReport(CustomGroupsPlugin::REPORT_NAME, [], '/' . $path));
+	}
+
+	public function testOnReportInvalidReportName() {
+		$path = 'test';
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/' . $path)
+			->will($this->returnValue($this->createMock('\Sabre\DAV\INode')));
+
+		$this->server->expects($this->any())
+			->method('getRequestUri')
+			->will($this->returnValue($path));
+		$this->plugin->initialize($this->server);
+
+		$this->assertNull($this->plugin->onReport('{whoever}whatever', [], '/' . $path));
+	}
+
+	public function reportNodesDataProvider() {
+		$cases = [];
+
+		$props = [
+			'{http://owncloud.org/ns}display-name',
+			'{http://owncloud.org/ns}role',
+		];
+
+		$groupNode1 = $this->createMock(GroupMembershipCollection::class);
+		$groupNode1->method('getName')->willReturn('group1');
+		$groupNode1->expects($this->once())
+			->method('getProperties')
+			->with($props)
+			->willReturn([
+				'{http://owncloud.org/ns}display-name' => 'Group One',
+				'{http://owncloud.org/ns}role' => 'admin',
+			]);
+		$groupNode2 = $this->createMock(GroupMembershipCollection::class);
+		$groupNode2->method('getName')->willReturn('group2');
+		$groupNode2->expects($this->once())
+			->method('getProperties')
+			->with($props)
+			->willReturn([
+				'{http://owncloud.org/ns}display-name' => 'Group Two',
+				'{http://owncloud.org/ns}role' => 'member',
+			]);
+
+		$cases[] = [
+			'customgroups/groups',
+			GroupsCollection::class,
+			GroupMembershipCollection::class,
+			$props,
+			[$groupNode1, $groupNode2],
+			[
+				[
+					'href' => 'customgroups/groups/group1',
+					200 => [
+						'{http://owncloud.org/ns}display-name' => 'Group One',
+						'{http://owncloud.org/ns}role' => 'admin',
+					],
+					404 => [],
+				],
+				[
+					'href' => 'customgroups/groups/group2',
+					200 => [
+						'{http://owncloud.org/ns}display-name' => 'Group Two',
+						'{http://owncloud.org/ns}role' => 'member',
+					],
+					404 => [],
+				],
+			]
+		];
+
+		$memberNode1 = $this->createMock(MembershipNode::class);
+		$memberNode1->method('getName')->willReturn('testuser');
+		$memberNode1->expects($this->once())
+			->method('getProperties')
+			->with($props)
+			->willReturn([
+				'{http://owncloud.org/ns}display-name' => 'Test User',
+				'{http://owncloud.org/ns}role' => 'admin',
+			]);
+		$memberNode2 = $this->createMock(MembershipNode::class);
+		$memberNode2->method('getName')->willReturn('user1');
+		$memberNode2->expects($this->once())
+			->method('getProperties')
+			->with($props)
+			->willReturn([
+				'{http://owncloud.org/ns}display-name' => 'User One',
+				'{http://owncloud.org/ns}role' => 'member',
+			]);
+		$cases[] = [
+			'customgroups/groups/group1',
+			GroupMembershipCollection::class,
+			MembershipNode::class,
+			$props,
+			[$memberNode1, $memberNode2],
+			[
+				[
+					'href' => 'customgroups/groups/group1/testuser',
+					200 => [
+						'{http://owncloud.org/ns}display-name' => 'Test User',
+						'{http://owncloud.org/ns}role' => 'admin',
+					],
+					404 => [],
+				],
+				[
+					'href' => 'customgroups/groups/group1/user1',
+					200 => [
+						'{http://owncloud.org/ns}display-name' => 'User One',
+						'{http://owncloud.org/ns}role' => 'member',
+					],
+					404 => [],
+				],
+			]
+		];
+
+		return $cases;
+	}
+
+	/**
+	 * @dataProvider reportNodesDataProvider
+	 */
+	public function testOnReportSearchGroupsCollection($reportTargetPath, $nodeClass, $resultClass, $props, $resultNodes, $expectedMultiStatus) {
+		$reportRequest = new ReportRequest($props, new Search('searchpattern', 12, 256));
+
+		$reportTargetNode = $this->createMock($nodeClass);
+		$reportTargetNode->expects($this->once())
+			->method('search')
+			->willReturn($resultNodes);
+
+		$response = $this->getMockBuilder('Sabre\HTTP\ResponseInterface')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$response->expects($this->once())
+			->method('setHeader')
+			->with('Content-Type', 'application/xml; charset=utf-8');
+
+		$response->expects($this->once())
+			->method('setStatus')
+			->with(207);
+
+		$response->expects($this->once())
+			->method('setBody');
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/' . $reportTargetPath)
+			->will($this->returnValue($reportTargetNode));
+
+		$this->server->expects($this->any())
+			->method('getRequestUri')
+			->will($this->returnValue($reportTargetPath));
+		$this->server->httpResponse = $response;
+		$this->plugin->initialize($this->server);
+
+		$this->server->expects($this->once())
+			->method('generateMultiStatus')
+			->with($expectedMultiStatus);
+
+		$this->assertFalse($this->plugin->onReport(CustomGroupsPlugin::REPORT_NAME, $reportRequest, '/' . $reportTargetPath));
+	}
+}
+

--- a/tests/unit/Dav/GroupMembershipCollectionTest.php
+++ b/tests/unit/Dav/GroupMembershipCollectionTest.php
@@ -374,7 +374,7 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 
 		$this->handler->expects($this->any())
 			->method('getGroupMembers')
-			->with(1, null, null)
+			->with(1, null)
 			->willReturn([
 				['group_id' => 1, 'user_id' => self::NODE_USER, 'role' => CustomGroupsDatabaseHandler::ROLE_ADMIN],
 				['group_id' => 1, 'user_id' => 'user3', 'role' => CustomGroupsDatabaseHandler::ROLE_MEMBER],
@@ -400,7 +400,7 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 
 		$this->handler->expects($this->any())
 			->method('getGroupMembers')
-			->with(1, null, $search)
+			->with(1, $search)
 			->willReturn([
 				['group_id' => 1, 'user_id' => self::NODE_USER, 'role' => CustomGroupsDatabaseHandler::ROLE_ADMIN],
 				['group_id' => 1, 'user_id' => 'user3', 'role' => CustomGroupsDatabaseHandler::ROLE_MEMBER],

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -130,7 +130,7 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->handler->expects($this->never())->method('getGroups');
 		$this->handler->expects($this->at(0))
 			->method('getUserMemberships')
-			->with('user1', null, null)
+			->with('user1', null)
 			->will($this->returnValue([
 				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
 				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],
@@ -152,7 +152,7 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->handler->expects($this->never())->method('getGroups');
 		$this->handler->expects($this->at(0))
 			->method('getUserMemberships')
-			->with('user1', null, $search)
+			->with('user1', $search)
 			->will($this->returnValue([
 				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
 				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -28,6 +28,7 @@ use OCP\IUser;
 use OCA\CustomGroups\Dav\GroupMembershipCollection;
 use OCA\CustomGroups\Dav\MembershipHelper;
 use OCP\IGroupManager;
+use OCA\CustomGroups\Search;
 
 /**
  * Class GroupsCollectionTest
@@ -90,6 +91,7 @@ class GroupsCollectionTest extends \Test\TestCase {
 	public function testListGroups() {
 		$this->handler->expects($this->at(0))
 			->method('getGroups')
+			->with(null)
 			->will($this->returnValue([
 				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
 				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],
@@ -104,18 +106,59 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->assertEquals('group2', $nodes[1]->getName());
 	}
 
-	public function testListGroupsFiltered() {
+	public function testListGroupsSearchPattern() {
+		$search = new Search('gr', 16, 256);
+		$this->handler->expects($this->at(0))
+			->method('getGroups')
+			->with($search)
+			->will($this->returnValue([
+				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
+				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],
+			]));
+
+		$nodes = $this->collection->search($search);
+		$this->assertCount(2, $nodes);
+
+		$this->assertInstanceOf(GroupMembershipCollection::class, $nodes[0]);
+		$this->assertEquals('group1', $nodes[0]->getName());
+		$this->assertInstanceOf(GroupMembershipCollection::class, $nodes[1]);
+		$this->assertEquals('group2', $nodes[1]->getName());
+	}
+
+	public function testListGroupsForUser() {
 		$collection = new GroupsCollection($this->handler, $this->helper, 'user1');
 		$this->handler->expects($this->never())->method('getGroups');
 		$this->handler->expects($this->at(0))
 			->method('getUserMemberships')
-			->with('user1')
+			->with('user1', null, null)
 			->will($this->returnValue([
 				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
 				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],
 			]));
 
 		$nodes = $collection->getChildren();
+		$this->assertCount(2, $nodes);
+
+		$this->assertInstanceOf(GroupMembershipCollection::class, $nodes[0]);
+		$this->assertEquals('group1', $nodes[0]->getName());
+		$this->assertInstanceOf(GroupMembershipCollection::class, $nodes[1]);
+		$this->assertEquals('group2', $nodes[1]->getName());
+	}
+
+	public function testListGroupsForUserSearchPattern() {
+		$search = new Search('gr', 16, 256);
+
+		$collection = new GroupsCollection($this->handler, $this->helper, 'user1');
+		$this->handler->expects($this->never())->method('getGroups');
+		$this->handler->expects($this->at(0))
+			->method('getUserMemberships')
+			->with('user1', null, $search)
+			->will($this->returnValue([
+				['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
+				['group_id' => 2, 'uri' => 'group2', 'display_name' => 'Group Two'],
+			]));
+
+		$nodes = $collection->search($search);
 		$this->assertCount(2, $nodes);
 
 		$this->assertInstanceOf(GroupMembershipCollection::class, $nodes[0]);


### PR DESCRIPTION
Fixes https://github.com/owncloud/customgroups/issues/16

Example report:
```xml
<?xml version="1.0" encoding="utf-8" ?>
<oc:search-query xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
        <a:prop>
                <oc:role></oc:role>
                <oc:display-name></oc:display-name>
        </a:prop>
        <oc:search>
                <oc:pattern>us</oc:pattern>
                <oc:limit>5</oc:limit>
                <oc:offset>0</oc:offset>
        </oc:search>
</oc:search-query>
```

You can apply this to the following URLs:
- groups list: `curl -i --data-binary "@report-customgroups.xml" -X REPORT -H "Content-Type: text/xml" http://admin:admin@localhost/owncloud/remote.php/dav/customgroups/groups`
- group members list: `curl -i --data-binary "@report-customgroups.xml" -X REPORT -H "Content-Type: text/xml" http://admin:admin@localhost/owncloud/remote.php/dav/customgroups/groups/group1`
- user membership list: `curl -i --data-binary "@report-customgroups.xml" -X REPORT -H "Content-Type: text/xml" http://admin:admin@localhost/owncloud/remote.php/dav/customgroups/users/user1/`

@DeepDiver1975 @jvillafanez please review.

If the implementation style is ok I'll add matching unit tests.

- [ ] unit tests
