### PR TITLE
Move "leave group" button in the title row

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,5 +1,4 @@
 
-
 /* FIXME: must be in core somewhere */
 #customgroups .icon {
 	display: inline-block;
@@ -36,11 +35,24 @@
 /* FIXME: integrate with core styles */
 #customgroups .sidebar .close {
 	position: absolute;
-	top: 0;
+	top: 9px;
 	right: 0;
 	padding: 15px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
+}
+
+#customgroups .sidebar .group-name-title {
+	float: left;
+}
+
+#customgroups .sidebar .action-leave-group {
+	float: right;
+	margin-right: 35px;
+}
+
+#customgroups .sidebar form {
+	clear: both;
 }
 
 #customgroups .avatar {

--- a/js/templates/membersListHeader.handlebars
+++ b/js/templates/membersListHeader.handlebars
@@ -2,10 +2,10 @@
 	<span class="avatar"></span>
 	<span class="group-name-title-display">{{groupName}}</span>
 </div>
-<a class="close action-close icon-close" href="#" alt="{{closeLabel}}"></a>
 {{#if userIsMember}}
 <input class="action-leave-group" type="button" value="{{leaveGroupLabel}}" />
 {{/if}}
+<a class="close action-close icon-close" href="#" alt="{{closeLabel}}"></a>
 
 {{#if canAdmin}}
 <form name="customGroupsAddMemberForm">


### PR DESCRIPTION
Looks better than before, but not yet optimal.

We can improve this further later with shorter texts and/or icons.
That here should be good enough for an alpha release.

@felixheidecke @pmaier1 @jvillafanez 

![customgroups-leave-title](https://cloud.githubusercontent.com/assets/277525/23761018/bd63698c-04f1-11e7-9e87-8930e0a4f84d.png)
