### PR TITLE
Return member display name when queried

### DIFF
--- a/js/MemberModel.js
+++ b/js/MemberModel.js
@@ -30,7 +30,8 @@
 		},
 
 		davProperties: {
-			'role': NS + 'role'
+			'role': NS + 'role',
+			'userDisplayName': NS + 'user-display-name'
 		}
 	});
 

--- a/js/MembersView.js
+++ b/js/MembersView.js
@@ -189,7 +189,7 @@
 
 			// TODO: use displayName once available
 			OC.dialogs.confirm(
-					t('customgroups', 'Are you sure that you want to remove the member "{name}" ?', {name: model.id}),
+					t('customgroups', 'Are you sure that you want to remove the member "{name}" ?', {name: model.get('userDisplayName')}),
 					t('customgroups', 'Confirm removal of member'),
 				function confirmCallback(confirmation) {
 					if (confirmation) {
@@ -258,7 +258,7 @@
 		_formatMember: function(member) {
 			return {
 				id: member.id,
-				displayName: member.id,
+				displayName: member.get('userDisplayName'),
 				canAdmin: OC.isUserAdmin() || this.model.get('role') === OCA.CustomGroups.ROLE_ADMIN,
 				roleDisplayName: (member.get('role') === OCA.CustomGroups.ROLE_ADMIN) ?
 					t('customgroups', 'Group admin') :

--- a/lib/Dav/MembershipNode.php
+++ b/lib/Dav/MembershipNode.php
@@ -36,6 +36,7 @@ class MembershipNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 
 	const PROPERTY_ROLE = '{http://owncloud.org/ns}role';
 	const PROPERTY_USER_ID = '{http://owncloud.org/ns}user-id';
+	const PROPERTY_USER_DISPLAY_NAME = '{http://owncloud.org/ns}user-display-name';
 
 	/**
 	 * Custom groups handler
@@ -57,13 +58,6 @@ class MembershipNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	 * @var MembershipHelper
 	 */
 	private $helper;
-
-	/**
-	 * Membership info for the currently logged in user
-	 *
-	 * @var array
-	 */
-	private $userMemberInfo;
 
 	/**
 	 * Node name
@@ -180,6 +174,17 @@ class MembershipNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 		}
 		if ($properties === null || in_array(self::PROPERTY_USER_ID, $properties)) {
 			$result[self::PROPERTY_USER_ID] = $this->memberInfo['user_id'];
+		}
+		if ($properties === null || in_array(self::PROPERTY_USER_DISPLAY_NAME, $properties)) {
+			// FIXME: extremely inefficient as it will query the display name
+			// for each user individually
+			$user = $this->helper->getUser($this->memberInfo['user_id']);
+			if ($user !== null) {
+				$result[self::PROPERTY_USER_DISPLAY_NAME] = $user->getDisplayName();
+			} else {
+				// possibly orphaned/deleted ?
+				$result[self::PROPERTY_USER_DISPLAY_NAME] = $this->memberInfo['user_id'];
+			}
 		}
 		return $result;
 	}

--- a/tests/js/MembersViewSpec.js
+++ b/tests/js/MembersViewSpec.js
@@ -68,16 +68,18 @@ describe('MembersView test', function() {
 		it('renders members as they are added', function() {
 			collection.add([{
 				id: 'user1',
+				userDisplayName: 'User One',
 				role: OCA.CustomGroups.ROLE_ADMIN
 			}, { 
 				id: 'user2',
+				userDisplayName: 'User Two',
 				role: OCA.CustomGroups.ROLE_MEMBER
 			}]);
 
 			expect(view.$('.group-member').length).toEqual(2);
-			expect(view.$('.group-member:eq(0) .user-display-name').text()).toEqual('user1');
+			expect(view.$('.group-member:eq(0) .user-display-name').text()).toEqual('User One');
 			expect(view.$('.group-member:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Group admin'));
-			expect(view.$('.group-member:eq(1) .user-display-name').text()).toEqual('user2');
+			expect(view.$('.group-member:eq(1) .user-display-name').text()).toEqual('User Two');
 			expect(view.$('.group-member:eq(1) .role-display-name').text()).toEqual(t('customgroups', 'Member'));
 
 			// avatar
@@ -139,16 +141,18 @@ describe('MembersView test', function() {
 		it('removes row when member deleted', function() {
 			var member1 = collection.add({
 				id: 'user1',
+				userDisplayName: 'User One',
 				role: OCA.CustomGroups.ROLE_ADMIN
 			});
 			var member2 = collection.add({
 				id: 'user2',
+				userDisplayName: 'User Two',
 				role: OCA.CustomGroups.ROLE_MEMBER
 			});
 
 			collection.remove(member1);
 			expect(view.$('.group-member').length).toEqual(1);
-			expect(view.$('.group-member:eq(0) .user-display-name').text()).toEqual('user2');
+			expect(view.$('.group-member:eq(0) .user-display-name').text()).toEqual('User Two');
 
 			collection.remove(member2);
 			expect(view.$('.group-member').length).toEqual(0);


### PR DESCRIPTION
Uses a barbaric method to retrieve the member display name: basically get the user from the user manager and call `$user->getDisplayName()`. Internally this will likely cause multiple queries like "does the user exist" and also "get the display name of that specific user".
So when dealing with a list of 20 entries there will be 20+ queries.

This should be changed once the user account table is ready and we might be able to join against it.

The current approach was done only for feature completion.

Please review @jvillafanez @DeepDiver1975 