### PR TITLE
Show settings section above 'additional' in admin

### DIFF
--- a/lib/SettingsSection.php
+++ b/lib/SettingsSection.php
@@ -27,7 +27,7 @@ class SettingsSection implements ISection {
 	}
 
 	public function getPriority() {
-		return 0;
+		return 10;
 	}
 
 	public function getIconName() {


### PR DESCRIPTION
Currently it shows below 'Additional' because the priority is set very low. Also made a PR in core to set the core section to a negative order:
https://github.com/owncloud/core/pull/28006/files