### PR TITLE
Changes to role display name

### DIFF
--- a/js/GroupsView.js
+++ b/js/GroupsView.js
@@ -320,6 +320,18 @@
 			return groupName;
 		},
 
+		_formatRoleLabel: function(role) {
+			if (OC.isUserAdmin()) {
+				return t('customgroups', 'Administrator');
+			}
+			if (role === OCA.CustomGroups.ROLE_ADMIN) {
+				return t('customgroups', 'Group owner');
+			} else if (role === OCA.CustomGroups.ROLE_MEMBER) {
+				return t('customgroups', 'Member');
+			}
+			return '';
+		},
+
 		_formatItem: function(group) {
 			return {
 				id: group.id,
@@ -327,9 +339,7 @@
 				renameLabel: t('customgroups', 'Rename'),
 				deleteLabel: t('customgroups', 'Delete'),
 				canAdmin: OC.isUserAdmin() || group.get('role') === OCA.CustomGroups.ROLE_ADMIN,
-				roleDisplayName: (group.get('role') === OCA.CustomGroups.ROLE_ADMIN) ?
-					t('customgroups', 'Group admin') :
-					t('customgroups', 'Member')
+				roleDisplayName: this._formatRoleLabel(group.get('role'))
 			};
 		},
 

--- a/js/MembersView.js
+++ b/js/MembersView.js
@@ -268,7 +268,7 @@
 				displayName: member.get('userDisplayName'),
 				canAdmin: OC.isUserAdmin() || this.model.get('role') === OCA.CustomGroups.ROLE_ADMIN,
 				roleDisplayName: (member.get('role') === OCA.CustomGroups.ROLE_ADMIN) ?
-					t('customgroups', 'Group admin') :
+					t('customgroups', 'Group owner') :
 					t('customgroups', 'Member')
 			};
 		},

--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -116,7 +116,7 @@ class Notifier implements INotifier {
 		if ($role === Roles::BACKEND_ROLE_MEMBER) {
 			return $l->t('Member');
 		} else if ($role === Roles::BACKEND_ROLE_ADMIN) {
-			return $l->t('Group admin');
+			return $l->t('Group owner');
 		}
 		return $l->t('Unknown role');
 	}

--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -144,7 +144,7 @@ Scenario: A non-admin member of a custom group cannot remove members
 					| member1 |
 					| member2 |
 
-Scenario: Group admin cannot remove self if no other admin exists in the group
+Scenario: Group owner cannot remove self if no other admin exists in the group
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists
@@ -244,7 +244,7 @@ Scenario: Superadmin can rename any custom group
 		When user "admin" renamed custom group "group0" as "renamed-group0"
 		Then custom group "group0" exists with display name "renamed-group0"
 
-Scenario: A member converted to admin can do the same as group admin
+Scenario: A member converted to group owner can do the same as group owner
 		Given As an "admin"
 		And user "user0" exists
 		And user "user1" exists
@@ -266,7 +266,7 @@ Scenario: A member converted to admin can do the same as group admin
 					| user1 |
 					| user2 |
 
-Scenario: A group admin cannot remove his own admin permissions if there is no other admin in the group
+Scenario: A group owner cannot remove his own admin permissions if there is no other owner in the group
 		Given As an "admin"
 		And user "user0" exists
 		And user "member1" exists

--- a/tests/js/GroupsViewSpec.js
+++ b/tests/js/GroupsViewSpec.js
@@ -50,7 +50,7 @@ describe('GroupsView test', function() {
 
 			expect(view.$('.group').length).toEqual(2);
 			expect(view.$('.group:eq(0) .group-display-name').text()).toEqual('Group One');
-			expect(view.$('.group:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Group admin'));
+			expect(view.$('.group:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Group owner'));
 			expect(view.$('.group:eq(1) .group-display-name').text()).toEqual('Group Two');
 			expect(view.$('.group:eq(1) .role-display-name').text()).toEqual(t('customgroups', 'Member'));
 
@@ -63,8 +63,20 @@ describe('GroupsView test', function() {
 			expect(imageplaceholderStub.getCall(1).args[0]).toEqual('group2:Group Two');
 			expect(imageplaceholderStub.getCall(1).args[1]).toEqual('Group Two');
 		});
+		it('renders role as "Administrator" for OC admins', function() {
+			var isAdminStub = sinon.stub(OC, 'isUserAdmin').returns(true);
+			collection.add([{
+				id: 'group1',
+				displayName: 'Group One',
+				role: OCA.CustomGroups.ROLE_MEMBER
+			}]);
 
-		it('renders admin actions when role is group admin', function() {
+			expect(view.$('.group:eq(0) .group-display-name').text()).toEqual('Group One');
+			expect(view.$('.group:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Administrator'));
+			isAdminStub.restore();
+		});
+
+		it('renders admin actions when role is group owner', function() {
 			collection.add({
 				id: 'group1',
 				displayName: 'Group One',

--- a/tests/js/MembersViewSpec.js
+++ b/tests/js/MembersViewSpec.js
@@ -78,7 +78,7 @@ describe('MembersView test', function() {
 
 			expect(view.$('.group-member').length).toEqual(2);
 			expect(view.$('.group-member:eq(0) .user-display-name').text()).toEqual('User One');
-			expect(view.$('.group-member:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Group admin'));
+			expect(view.$('.group-member:eq(0) .role-display-name').text()).toEqual(t('customgroups', 'Group owner'));
 			expect(view.$('.group-member:eq(1) .user-display-name').text()).toEqual('User Two');
 			expect(view.$('.group-member:eq(1) .role-display-name').text()).toEqual(t('customgroups', 'Member'));
 
@@ -92,7 +92,7 @@ describe('MembersView test', function() {
 			expect(avatarStub.getCall(1).args[1]).toEqual(32);
 		});
 
-		it('renders admin actions when user\'s role in group is group admin', function() {
+		it('renders admin actions when user\'s role in group is group owner', function() {
 			model.set({
 				role: OCA.CustomGroups.ROLE_ADMIN
 			});

--- a/tests/unit/NotifierTest.php
+++ b/tests/unit/NotifierTest.php
@@ -110,7 +110,7 @@ class NotifierTest extends \Test\TestCase {
 			->with('Role change in group "group1".');
 		$notification->expects($this->once())
 			->method('setParsedMessage')
-			->with('"user1" assigned the "Group admin" role for the group "group1" to you.');
+			->with('"user1" assigned the "Group owner" role for the group "group1" to you.');
 
 		$notification = $this->notifier->prepare($notification, 'en_US');
 	}


### PR DESCRIPTION
- ownCloud administrators always see "Administrator"
- renamed "Group admin" to "Group owner"

Fixes https://github.com/owncloud/customgroups/issues/58
Fixes https://github.com/owncloud/customgroups/issues/66