### PR TITLE
Allow restricting group creation to subadmins

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<repository type="git">http://github.com/owncloud/customgroups.git</repository>
 	<licence>AGPL</licence>
 	<author>Vincent Petry</author>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 	<category>collaboration</category>
 	<screenshot>https://github.com/owncloud/screenshots/raw/a28a6cf38ed8d18d98a02fb7ecac82d1a264a791/customgroups/customgroups-screenshot.png</screenshot>
 	<types>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,9 +29,11 @@
 		</collections>
 	</sabre>
 	<settings>
+		<admin>OCA\CustomGroups\AdminPanel</admin>
 		<personal>OCA\CustomGroups\SettingsPanel</personal>
 	</settings>
 	<settings-sections>
+		<admin>OCA\CustomGroups\SettingsSection</admin>
 		<personal>OCA\CustomGroups\SettingsSection</personal>
 	</settings-sections>
 </info>

--- a/js/App.js
+++ b/js/App.js
@@ -15,12 +15,20 @@
 			'click .sidebar .action-close': '_onClickClose'
 		},
 
-		initialize: function() {
+		initialize: function(options) {
+			options = _.extend({
+				canCreate: true
+			}, options);
+
 			this.collection = new OCA.CustomGroups.GroupsCollection([], {
 				// admins can see all groups so don't set a user filter
 				userId: (OC.isUserAdmin() ? null : OC.getCurrentUser().uid)
 			});
-			this.listView = new OCA.CustomGroups.GroupsView(this.collection);
+			this.listView = new OCA.CustomGroups.GroupsView(
+				this.collection, {
+					canCreate: options.canCreate
+				}
+			);
 			this.listView.on('select', this._onSelectGroup, this);
 
 			this.render();
@@ -79,6 +87,9 @@
 })(OCA);
 
 $(document).ready(function() {
-	var app = new OCA.CustomGroups.App();
-	$('#customgroups').append(app.$el);
+	var $container = $('#customgroups');
+	var app = new OCA.CustomGroups.App({
+		canCreate: $container.attr('data-cancreategroups') !== 'false'
+	});
+	$container.append(app.$el);
 });

--- a/js/GroupsView.js
+++ b/js/GroupsView.js
@@ -21,6 +21,8 @@
 
 		_lastActive: null,
 
+		_canCreate: true,
+
 		events: {
 			'submit form': '_onSubmitCreationForm',
 			'submit form.group-rename-form': '_onSubmitRename',
@@ -31,8 +33,13 @@
 			'click .action-delete-group': '_onDeleteGroup'
 		},
 
-		initialize: function(collection) {
+		initialize: function(collection, options) {
 			this.collection = collection;
+			options = _.extend({}, options);
+
+			if (!_.isUndefined(options.canCreate)) {
+				this._canCreate = !!options.canCreate;
+			}
 
 			this.collection.on('request', this._onRequest, this);
 			this.collection.on('sync destroy', this._onEndRequest, this);
@@ -348,7 +355,8 @@
 				newGroupSubmitLabel: t('customgroups', 'Create group'),
 				groupLabel: t('customgroups', 'Group'),
 				yourRoleLabel: t('customgroups', 'Your role'),
-				emptyMessage: t('customgroups', 'There are currently no user defined groups')
+				emptyMessage: t('customgroups', 'There are currently no user defined groups'),
+				canCreate: this._canCreate
 			}));
 			this.$container = this.$('.group-list');
 			this.$renameForm = this.$('.group-rename-form').detach();

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+
+	$('#customgroups-admin input').change(function() {
+		var value = 'false';
+		if (this.checked) {
+			value = 'true';
+		}
+		OC.AppConfig.setValue('customgroups', $(this).attr('name'), value);
+	});
+
+	$('.section .icon-info').tipsy({gravity: 'w'});
+});

--- a/js/templates/list.handlebars
+++ b/js/templates/list.handlebars
@@ -1,9 +1,11 @@
+{{#canCreate}}
 <form name="customGroupsCreationForm">
 	<div>
 		<input type="text" name="groupName" placeholder="{{newGroupPlaceholder}}" autocomplete="off" autocapitalize="off" autocorrect="off">
 		<input type="submit" value="{{newGroupSubmitLabel}}" />
 	</div>
 </form>
+{{/canCreate}}
 <form name="customGroupsRenameForm" class="hidden group-rename-form">
 	<input type="text" value="" placeholder="{{newGroupPlaceholder}}" />
 </form>

--- a/lib/AdminPanel.php
+++ b/lib/AdminPanel.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups;
+
+use OCP\Settings\ISettings;
+use OCP\Template;
+use OCP\IConfig;
+
+class AdminPanel implements ISettings {
+
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getPanel() {
+		$tmpl = new Template('customgroups', 'admin');
+		$restrictToSubadmins = $this->config->getAppValue('customgroups', 'only_subadmin_can_create', 'false') === 'true';
+		$tmpl->assign('onlySubAdminCanCreate', $restrictToSubadmins);
+		return $tmpl;
+	}
+
+	public function getPriority() {
+		return 0;
+	}
+
+	public function getSectionID() {
+		return 'customgroups';
+	}
+
+}

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -24,6 +24,7 @@ namespace OCA\CustomGroups\Dav;
 use Sabre\DAV\ICollection;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\Forbidden;
 
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use OCA\CustomGroups\Search;

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -89,6 +89,9 @@ class GroupsCollection implements ICollection {
 	 * @throws MethodNotAllowed if the group already exists
 	 */
 	public function createDirectory($name) {
+		if (!$this->helper->canCreateGroups()) {
+			throw new Forbidden('No permission to create groups');
+		}
 		$groupId = $this->groupsHandler->createGroup($name, $name);
 		if (is_null($groupId)) {
 			throw new MethodNotAllowed("Group with uri \"$name\" already exists");

--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -330,28 +330,19 @@ class MembershipHelper {
 		$this->notificationManager->notify($notification);
 	}
 
+	/**
+	 * Returns whether the current user is allowed to create custom groups.
+	 *
+	 * @return bool true if allowed, false otherwise
+	 */
 	public function canCreateGroups() {
-		$restrictToSubadmins = $this->config->getAppValue('customgroups', 'only_subadmin_can_create', null) === 'true';
+		$restrictToSubadmins = $this->config->getAppValue('customgroups', 'only_subadmin_can_create', 'false') === 'true';
 
-		if (!$restrictToSubadmins) {
-			return true;
-		}
-
-		// ownCloud admin can
-		if ($this->isUserSuperAdmin()) {
-			return true;
-		}
-
-		// subadmin of at least one group can
-		$subAdminGroups = $this->groupManager->getSubAdmin()->getSubAdminsGroups($this->userSession->getUser());
-		if (!empty($subAdminGroups)) {
-			return true;
-		}
-
-		return false;
-	}
-
-	public function canRenameGroups() {
-		return $this->canCreateGroups();
+		// if the restriction is set, only admins or subadmins are allowed to create, not regular users
+		return (
+			!$restrictToSubadmins
+			|| $this->isUserSuperAdmin()
+			|| $this->groupManager->getSubAdmin()->isSubAdmin($this->userSession->getUser())
+		);
 	}
 }

--- a/lib/SettingsPanel.php
+++ b/lib/SettingsPanel.php
@@ -23,10 +23,14 @@ namespace OCA\CustomGroups;
 
 use OCP\Settings\ISettings;
 use OCP\Template;
+use OCA\CustomGroups\Service\MembershipHelper;
 
 class SettingsPanel implements ISettings {
 
-	public function __construct() {
+	private $helper;
+
+	public function __construct(MembershipHelper $helper) {
+		$this->helper = $helper;
 	}
 
 	public function getPanel() {
@@ -34,6 +38,7 @@ class SettingsPanel implements ISettings {
 		$modules = json_decode(file_get_contents(__DIR__ . '/../js/modules.json'), true);
 		$tmpl = new Template('customgroups', 'index');
 		$tmpl->assign('modules', $modules);
+		$tmpl->assign('canCreateGroups', $this->helper->canCreateGroups());
 		return $tmpl;
 	}
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+script('customgroups', 'admin');
+?>
+
+<div id="customgroups-admin" class="section">
+	<h2><?php p($l->t('Custom Groups'));?></h2>
+
+	<p>
+		<input type="checkbox" name="only_subadmin_can_create" id="onlySubAdminCanCreate" class="checkbox"
+			   value="1" <?php if ($_['onlySubAdminCanCreate']) print_unescaped('checked="checked"'); ?> />
+		<label for="onlySubAdminCanCreate">
+			<?php p($l->t('Only group admins are allowed to create custom groups'));?>
+		</label>
+	</p>
+</div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -30,4 +30,4 @@ foreach ($_['modules'] as $module) {
 }
 ?>
 
-<div id="customgroups" class="section"></div>
+<div id="customgroups" class="section" data-cancreategroups="<?php p($_['canCreateGroups'] ? 'true' : 'false') ?>"></div>

--- a/tests/js/GroupsViewSpec.js
+++ b/tests/js/GroupsViewSpec.js
@@ -32,7 +32,7 @@ describe('GroupsView test', function() {
 		beforeEach(function() {
 			view.render();
 		});
-		
+
 		it('renders empty list at first', function() {
 			expect(view.$('.group-list').length).toBeDefined();
 		});
@@ -204,6 +204,19 @@ describe('GroupsView test', function() {
 			collection = sinon.createStubInstance(OCA.CustomGroups.GroupsCollection);
 			view = new OCA.CustomGroups.GroupsView(collection);
 			view.render();
+		});
+
+		it('renders creation form when allowed', function() {
+			expect(view.$('[name=customGroupsCreationForm]').length).toEqual(1);
+		});
+
+		it('does not render creation form when creation is not allowed', function() {
+			view.remove();
+			collection = sinon.createStubInstance(OCA.CustomGroups.GroupsCollection);
+			view = new OCA.CustomGroups.GroupsView(collection, {canCreate: false});
+			view.render();
+
+			expect(view.$('[name=customGroupsCreationForm]').length).toEqual(0);
 		});
 
 		it('creates group into collection and selects it', function() {

--- a/tests/unit/Dav/GroupMembershipCollectionTest.php
+++ b/tests/unit/Dav/GroupMembershipCollectionTest.php
@@ -32,6 +32,7 @@ use OCP\IGroupManager;
 use OCA\CustomGroups\Search;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
+use OCP\IConfig;
 
 /**
  * Class GroupMembershipCollectionTest
@@ -101,7 +102,8 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 				$this->userManager,
 				$this->groupManager,
 				$this->createMock(IManager::class),
-				$this->createMock(IURLGenerator::class)
+				$this->createMock(IURLGenerator::class),
+				$this->createMock(IConfig::class)
 			])
 			->getMock();
 

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -31,6 +31,7 @@ use OCP\IGroupManager;
 use OCA\CustomGroups\Search;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
+use OCP\IConfig;
 
 /**
  * Class GroupsCollectionTest
@@ -82,7 +83,8 @@ class GroupsCollectionTest extends \Test\TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->createMock(IManager::class),
-			$this->createMock(IURLGenerator::class)
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(IConfig::class)
 		);
 		$this->collection = new GroupsCollection($this->handler, $this->helper);
 	}
@@ -183,6 +185,25 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->handler->expects($this->at(1))
 			->method('addToGroup')
 			->with('user1', 1, true);
+
+		$this->collection->createDirectory('group1');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testCreateGroupNoPermission() {
+		$helper = $this->createMock(MembershipHelper::class);
+		$helper->expects($this->once())
+			->method('canCreateGroups')
+			->willReturn(false);
+
+		$this->collection = new GroupsCollection($this->handler, $helper);
+
+		$this->handler->expects($this->never())
+			->method('createGroup');
+		$this->handler->expects($this->never())
+			->method('addToGroup');
 
 		$this->collection->createDirectory('group1');
 	}

--- a/tests/unit/Dav/MembershipNodeTest.php
+++ b/tests/unit/Dav/MembershipNodeTest.php
@@ -32,6 +32,7 @@ use OCA\CustomGroups\Dav\Roles;
 use OCA\CustomGroups\Search;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
+use OCP\IConfig;
 
 /**
  * Class MembershipNodeTest
@@ -96,7 +97,8 @@ class MembershipNodeTest extends \Test\TestCase {
 				$this->userManager,
 				$this->groupManager,
 				$this->createMock(IManager::class),
-				$this->createMock(IURLGenerator::class)
+				$this->createMock(IURLGenerator::class),
+				$this->createMock(IConfig::class)
 			])
 			->getMock();
 
@@ -198,7 +200,8 @@ class MembershipNodeTest extends \Test\TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->createMock(IManager::class),
-			$this->createMock(IURLGenerator::class)
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(IConfig::class)
 		);
 
 		$memberInfo = ['group_id' => 1, 'user_id' => self::NODE_USER, 'role' => $role];

--- a/tests/unit/Dav/UsersCollectionTest.php
+++ b/tests/unit/Dav/UsersCollectionTest.php
@@ -30,6 +30,7 @@ use OCP\IGroupManager;
 use OCA\CustomGroups\Dav\GroupsCollection;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
+use OCP\IConfig;
 
 /**
  * Class UsersCollectionTest
@@ -88,7 +89,8 @@ class UsersCollectionTest extends \Test\TestCase {
 			$this->userManager,
 			$this->groupManager,
 			$this->createMock(IManager::class),
-			$this->createMock(IURLGenerator::class)
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(IConfig::class)
 		);
 
 		$this->collection = new UsersCollection($this->handler, $this->helper);

--- a/tests/unit/SettingsPanelTest.php
+++ b/tests/unit/SettingsPanelTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Vincent Petry
+ * @copyright 2017 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\CustomGroups\Tests\unit;
+
+use OCA\CustomGroups\Service\MembershipHelper;
+use OCA\CustomGroups\SettingsPanel;
+
+/**
+ * @package OCA\CustomGrouops\Tests\unit
+ */
+class SettingsPanelTest extends \Test\TestCase {
+
+	/**
+	 * @var SettingsPanel
+	 */
+	private $panel;
+
+	/**
+	 * @var MembershipHelper
+	 */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		$this->helper = $this->createMock(MembershipHelper::class);
+		$this->panel = new SettingsPanel($this->helper);
+	}
+
+	public function testGetSection() {
+		$this->assertEquals('customgroups', $this->panel->getSectionID());
+	}
+
+	public function testGetPriority() {
+		$this->assertTrue(is_integer($this->panel->getPriority()));
+	}
+
+	public function testGetPanel() {
+		$this->helper->expects($this->once())
+			->method('canCreateGroups')
+			->willReturn(true);
+		$templateHtml = $this->panel->getPanel()->fetchPage();
+		$this->assertContains('<div id="customgroups" class="section" data-cancreategroups="true"></div>', $templateHtml);
+	}
+
+	public function testGetPanelNoCreatePerm() {
+		$this->helper->expects($this->once())
+			->method('canCreateGroups')
+			->willReturn(false);
+		$templateHtml = $this->panel->getPanel()->fetchPage();
+		$this->assertContains('<div id="customgroups" class="section" data-cancreategroups="false"></div>', $templateHtml);
+	}
+}


### PR DESCRIPTION
To test:

1. Login as OC admin
1. ~~`occ config:app:set customgroups only_subadmin_can_create --value="true"` (there is currently no checkbox)~~
1. Go to settings page, and to "Custom groups" in the bottom admin section.
1. Tick the checkbox to enable the restriction.
1. Create a user "user1" as group admin of group "group1"
1. Create a user "user2" without further permissions
1. Login as "user1" who is a group admin
1. Create a custom groups "customgroup1"
1. Add "user2" to custom group "customgroup1"
1. Login as "user2"
1. See that the custom group appears in the list but no changes can be made. Cannot create groups.
1. Login as "user1"
1. Now make "user2" an admin of custom group "customgroup1"
1. Login as "user2"
1. See that while you cannot create new groups you can make changes to the custom group "customgroup1"

TODOs:
- [ ] adjust behavior if requirements are different ?
- [x] fix unit tests to cover more
- [x] add visible checkbox in the web UI for the setting

@pmaier1 @haukman @felixboehm 
