### PR TITLE
Move restriction checkbox to the sharing section

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,6 @@
 		<personal>OCA\CustomGroups\SettingsPanel</personal>
 	</settings>
 	<settings-sections>
-		<admin>OCA\CustomGroups\SettingsSection</admin>
 		<personal>OCA\CustomGroups\SettingsSection</personal>
 	</settings-sections>
 </info>

--- a/lib/AdminPanel.php
+++ b/lib/AdminPanel.php
@@ -48,7 +48,7 @@ class AdminPanel implements ISettings {
 	}
 
 	public function getSectionID() {
-		return 'customgroups';
+		return 'sharing';
 	}
 
 }


### PR DESCRIPTION
@pmaier1 happy ?

![customgroups-sharing](https://user-images.githubusercontent.com/277525/27378945-c318f1ba-5679-11e7-9a76-6928e5eb4b82.png)

I'm just a bit worried that admins won't think about going to look there.