### PR TITLE
Implement method that returns users in group

### DIFF
--- a/lib/CustomGroupsBackend.php
+++ b/lib/CustomGroupsBackend.php
@@ -135,7 +135,7 @@ class CustomGroupsBackend implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * Not supported, returns an empty array.
+	 * Returns all users in a custom group.
 	 *
 	 * @param string $gid group id
 	 * @param string $search search string
@@ -144,8 +144,22 @@ class CustomGroupsBackend implements \OCP\GroupInterface {
 	 * @return array empty array
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$uri = $this->extractUri($gid);
+		if (is_null($uri)) {
+			return [];
+		}
+
+		$group = $this->handler->getGroupByUri($uri);
+		if (is_null($group)) {
+			return null;
+		}
+
 		// not exposed to regular user management
-		return [];
+		$search = new Search($search, $offset, $limit);
+		$memberInfo = $this->handler->getGroupMembers($group['group_id'], $search);
+		return array_map(function ($memberInfo) {
+			return $memberInfo['user_id'];
+		}, $memberInfo);
 	}
 
 	/**

--- a/tests/unit/CustomGroupsBackendTest.php
+++ b/tests/unit/CustomGroupsBackendTest.php
@@ -145,9 +145,21 @@ class CustomGroupsBackendTest extends \Test\TestCase {
 	}
 
 	public function testUsersInGroup() {
-		$this->handler->expects($this->never())->method('getGroup');
-		$this->handler->expects($this->never())->method('getGroupMembers');
-		$this->assertEquals([], $this->backend->usersInGroup(self::GROUP_ID_PREFIX . 'one'));
+		$this->handler->expects($this->once())
+			->method('getGroupByUri')
+			->with('one')
+			->willReturn(['group_id' => 1, 'display_name' => 'Group One']);
+		$this->handler->expects($this->once())
+			->method('getGroupMembers')
+			->with(1, new Search('ser', 5, 10))
+			->willReturn([
+				['user_id' => 'user1'],
+				['user_id' => 'user2'],
+			]);
+		$this->assertEquals(
+			['user1', 'user2'],
+			$this->backend->usersInGroup(self::GROUP_ID_PREFIX . 'one', 'ser', 10, 5)
+		);
 	}
 
 }


### PR DESCRIPTION
Required for some apps like activity which use this to find out what
group members there are to send emails to. This could have other side
effects.
