### PR TITLE
Prevent duplicate display names

### DIFF
--- a/lib/AdminPanel.php
+++ b/lib/AdminPanel.php
@@ -40,6 +40,8 @@ class AdminPanel implements ISettings {
 		$tmpl = new Template('customgroups', 'admin');
 		$restrictToSubadmins = $this->config->getAppValue('customgroups', 'only_subadmin_can_create', 'false') === 'true';
 		$tmpl->assign('onlySubAdminCanCreate', $restrictToSubadmins);
+		$allowDuplicateNames = $this->config->getAppValue('customgroups', 'allow_duplicate_names', 'false') === 'true';
+		$tmpl->assign('allowDuplicateNames', $allowDuplicateNames);
 		return $tmpl;
 	}
 

--- a/lib/CustomGroupsDatabaseHandler.php
+++ b/lib/CustomGroupsDatabaseHandler.php
@@ -188,15 +188,15 @@ class CustomGroupsDatabaseHandler {
 	 * Returns the info for a given group.
 	 *
 	 * @param string $field field to filter by
-	 * @param string $numericGroupId numeric group id
+	 * @param string $fieldValue field value
 	 * @return array|null group info or null if not found
 	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
 	 */
-	private function getGroupBy($field, $numericGroupId) {
+	private function getGroupBy($field, $fieldValue) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$cursor = $qb->select(['group_id', 'uri', 'display_name'])
 			->from('custom_group')
-			->where($qb->expr()->eq($field, $qb->createNamedParameter($numericGroupId)))
+			->where($qb->expr()->eq($field, $qb->createNamedParameter($fieldValue)))
 			->execute();
 		$result = $cursor->fetch();
 		$cursor->closeCursor();
@@ -206,6 +206,26 @@ class CustomGroupsDatabaseHandler {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Get groups by display name in a case-insensitive manner.
+	 *
+	 * @param string $displayName numeric group id
+	 * @return array[] array of group infos
+	 * @throws \Doctrine\DBAL\Exception\DriverException in case of database exception
+	 */
+	public function getGroupsByDisplayName($displayName) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select(['group_id', 'uri', 'display_name'])
+			->from('custom_group')
+			->where($qb->expr()->eq($qb->createFunction('LOWER(`display_name`)'), $qb->createNamedParameter(strtolower($displayName))))
+			->execute();
+
+		$results = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		return $results;
 	}
 
 	/**

--- a/lib/Dav/GroupMembershipCollection.php
+++ b/lib/Dav/GroupMembershipCollection.php
@@ -274,6 +274,10 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 			return 403;
 		}
 
+		if ($this->groupInfo['display_name'] !== $displayName && !$this->helper->isGroupDisplayNameAvailable($displayName)) {
+			return 409;
+		}
+
 		$result = $this->groupsHandler->updateGroup(
 			$this->groupInfo['group_id'],
 			$this->groupInfo['uri'],

--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -356,4 +356,21 @@ class MembershipHelper {
 			|| $this->groupManager->getSubAdmin()->isSubAdmin($this->userSession->getUser())
 		);
 	}
+
+	/**
+	 * Checks whether the given display name exists, if applicable from the configuration
+	 *
+	 * @param string $displayName group display name
+	 * @return bool true if a duplicate group was found and the operation is not allowed, false if
+	 * no duplicate group was found or duplicates are allowed
+	 */
+	public function isGroupDisplayNameAvailable($displayName) {
+		if ($this->config->getAppValue('customgroups', 'allow_duplicate_names', 'false') === 'true') {
+			return true;
+		}
+
+		$groups = $this->groupsHandler->getGroupsByDisplayName($displayName);
+
+		return empty($groups);
+	}
 }

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -32,4 +32,11 @@ script('customgroups', 'admin');
 			<?php p($l->t('Only group admins are allowed to create custom groups'));?>
 		</label>
 	</p>
+	<p>
+		<input type="checkbox" name="allow_duplicate_names" id="allowDuplicateNames" class="checkbox"
+			   value="1" <?php if ($_['allowDuplicateNames']) print_unescaped('checked="checked"'); ?> />
+		<label for="allowDuplicateNames">
+			<?php p($l->t('Allow creating multiple groups with the same name'));?>
+		</label>
+	</p>
 </div>

--- a/tests/js/GroupsViewSpec.js
+++ b/tests/js/GroupsViewSpec.js
@@ -279,7 +279,7 @@ describe('GroupsView test', function() {
 			});
 		});
 
-		it('shows notification in case of error', function() {
+		it('shows notification in case of duplicate group error', function() {
 			var notificationStub = sinon.stub(OC.Notification, 'showTemporary');
 			view.$('[name=groupName]').val('newgroup');
 			view.$('[name=customGroupsCreationForm]').submit();
@@ -291,9 +291,10 @@ describe('GroupsView test', function() {
 				role: OCA.CustomGroups.ROLE_ADMIN
 			});
 
-			collection.create.yieldTo('error', collection, {status: 404} );
+			collection.create.yieldTo('error', collection, {status: 409} );
 
 			expect(notificationStub.calledOnce).toEqual(true);
+			expect(notificationStub.calledWith('A group with this name already exists')).toEqual(true);
 
 			notificationStub.restore();
 		});
@@ -349,6 +350,21 @@ describe('GroupsView test', function() {
 				$groupEl.find('input').trigger($.Event('keyup', {keyCode: 27}));
 				expect(model.save.notCalled).toEqual(true);
 				expect($groupEl.find('input').length).toEqual(0);
+			});
+			it('notifies in case of duplicate group error', function() {
+				var notificationStub = sinon.stub(OC.Notification, 'showTemporary');
+				$groupEl.find('.action-rename-group').click();
+				$groupEl.find('input').val('Group Renamed');
+				$groupEl.find('form').submit();
+				expect(model.save.calledOnce).toEqual(true);
+				model.save.yieldTo('error', model, {status: 422});
+
+				expect($groupEl.find('input').length).toEqual(0);
+
+				expect(notificationStub.calledOnce).toEqual(true);
+				expect(notificationStub.calledWith('A group with this name already exists')).toEqual(true);
+
+				notificationStub.restore();
 			});
 		});
 		describe('delete group', function() {

--- a/tests/unit/CustomGroupsDatabaseHandlerTest.php
+++ b/tests/unit/CustomGroupsDatabaseHandlerTest.php
@@ -182,6 +182,25 @@ class CustomGroupsDatabaseHandlerTest extends \Test\TestCase {
 		$this->assertEquals($group1Id, $results[2]['group_id']);
 	}
 
+	public function testGetGroupsByDisplayName() {
+		$group1Id = $this->handler->createGroup('my_group_1', 'One');
+		$group2Id = $this->handler->createGroup('my_group_2', 'Two');
+		$group3Id = $this->handler->createGroup('my_group_3', 'One');
+
+		$results = $this->handler->getGroupsByDisplayName('one');
+
+		$this->assertCount(2, $results);
+
+		$this->assertEquals('my_group_1', $results[0]['uri']);
+		$this->assertEquals('One', $results[0]['display_name']);
+		$this->assertEquals($group1Id, $results[0]['group_id']);
+
+		$this->assertEquals('my_group_3', $results[1]['uri']);
+		$this->assertEquals('One', $results[1]['display_name']);
+		$this->assertEquals($group3Id, $results[1]['group_id']);
+
+	}
+
 	public function testAddToGroup() {
 		$groupId = $this->handler->createGroup('my_group', 'My Group');
 

--- a/tests/unit/Service/MembershipHelperTest.php
+++ b/tests/unit/Service/MembershipHelperTest.php
@@ -547,4 +547,44 @@ class MembershipHelperTest extends \Test\TestCase {
 
 		$this->assertEquals($expectedResult, $this->helper->canCreateGroups());
 	}
+
+	public function testIsGroupDisplayNameAvailableWhenDuplicatesAreAllowed() {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('customgroups', 'allow_duplicate_names', 'false')
+			->willReturn('true');
+
+		$this->handler->expects($this->never())
+			->method('getGroupsByDisplayName');
+
+		$this->assertTrue($this->helper->isGroupDisplayNameAvailable('test'));
+	}
+
+	public function testIsGroupDisplayNameAvailableNoDuplicateExists() {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('customgroups', 'allow_duplicate_names', 'false')
+			->willReturn('false');
+
+		$this->handler->expects($this->once())
+			->method('getGroupsByDisplayName')
+			->with('test')
+			->willReturn([]);
+
+		$this->assertTrue($this->helper->isGroupDisplayNameAvailable('test'));
+	}
+
+	public function testIsGroupDisplayNameAvailableDuplicateExists() {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('customgroups', 'allow_duplicate_names', 'false')
+			->willReturn('false');
+
+		$this->handler->expects($this->once())
+			->method('getGroupsByDisplayName')
+			->with('test')
+			->willReturn([['duplicate']]);
+
+		$this->assertFalse($this->helper->isGroupDisplayNameAvailable('test'));
+	}
 }


### PR DESCRIPTION
Prevents duplicate display names

Fixes https://github.com/owncloud/customgroups/issues/77

- [x] backend prevention
- [x] option to allow duplicates
- [x] catch duplicate error when creating group
- [x] catch duplicate error when renaming group
    - [x] make field reappear, etc
    - [x] REQUIRES: PROPPATCH error detection https://github.com/owncloud/core/pull/28589


