### PR TITLE
Prevent registering select event twice on autocomplete

### DIFF
--- a/js/MembersView.js
+++ b/js/MembersView.js
@@ -322,6 +322,7 @@
 				);
 			}
 
+			this.membersInput.off('select', this._onAddMember, this);
 			this.membersInput.render();
 			this.membersInput.on('select', this._onAddMember, this);
 			this.$('.add-member-container').append(this.membersInput.$el);

--- a/tests/js/MembersViewSpec.js
+++ b/tests/js/MembersViewSpec.js
@@ -218,6 +218,17 @@ describe('MembersView test', function() {
 
 			notificationStub.restore();
 		});
+
+		it('rerendering header after rename does not double register select event', function() {
+			// this will rerender the header
+			model.set('displayName', 'renamed');
+			view.membersInput.trigger('select', {
+				userId: 'newuser',
+				displayName: 'new user display name'
+			});
+			// only called once
+			expect(collection.create.calledOnce).toEqual(true);
+		});
 	});
 
 	describe('actions', function() {


### PR DESCRIPTION
This would happen when renaming a group, which triggers a rerender of
the members pane header which would re-register the select event.

This fix unregisters prevent event before reregistering.

