### PR TITLE
Improve spinners in members view

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -78,6 +78,14 @@
 	max-width: 1px;
 }
 
+#customgroups .loading-list {
+	margin-top: 10px;
+}
+
+#customgroups .icon-loading-small {
+	margin-left: 10px;
+}
+
 .customgroups-autocomplete-item {
 	display: flex;
 }

--- a/js/MembersView.js
+++ b/js/MembersView.js
@@ -41,8 +41,12 @@
 				groupUri: this.model.id
 			});
 
+			var self = this;
 			this.collection.reset([], {silent: true});
 			this.collection.fetch();
+			_.defer(function() {
+				self._toggleLoading(true);
+			});
 
 			_.bindAll(
 				this,
@@ -65,11 +69,11 @@
 
 		_toggleLoading: function(state) {
 			this._loading = state;
-			this.$('.loading').toggleClass('hidden', !state);
+			this.$('.loading-list').toggleClass('hidden', !state);
+			this.$('.grid').toggleClass('hidden', state);
 		},
 
 		_onRequest: function() {
-			this._toggleLoading(true);
 			this.$('.empty').addClass('hidden');
 		},
 
@@ -147,6 +151,8 @@
 			}
 
 			$field.prop('disabled', true);
+			var $loading = this.$('.member-input-view .loading');
+			$loading.removeClass('hidden');
 
 			this.collection.create({
 				id: userId,
@@ -154,10 +160,12 @@
 			},  {
 				wait: true,
 				success: function() {
+					$loading.addClass('hidden');
 					$field.prop('disabled', false);
 					$field.val('').focus();
 				},
 				error: function(model, response) {
+					$loading.addClass('hidden');
 					$field.prop('disabled', false);
 					$field.val('').focus();
 					if (response.status === 412) {
@@ -215,9 +223,12 @@
 		_onChangeMemberRole: function(ev) {
 			ev.preventDefault();
 			var self = this;
-			var $row = $(ev.target).closest('.group-member');
+			var $target = $(ev.target);
+			var $row = $target.closest('.group-member');
 			var id = $row.attr('data-id');
 			var model = this.collection.findWhere({'id': id});
+			$target.next('.loading').removeClass('hidden');
+			$target.tooltip('hide').remove();
 
 			if (!model) {
 				return;
@@ -232,6 +243,8 @@
 				model.save({
 					role: newRole
 				}, {
+					wait: true,
+					patch: true,
 					success: function() {
 						if (rerender) {
 							// refresh permission actions

--- a/js/MembersView.js
+++ b/js/MembersView.js
@@ -227,14 +227,14 @@
 			var $row = $target.closest('.group-member');
 			var id = $row.attr('data-id');
 			var model = this.collection.findWhere({'id': id});
-			$target.next('.loading').removeClass('hidden');
-			$target.tooltip('hide').remove();
 
 			if (!model) {
 				return;
 			}
 
 			function action(rerender) {
+				$target.next('.loading').removeClass('hidden');
+				$target.tooltip('hide').remove();
 				// swap permissions
 				var newRole = (model.get('role') === OCA.CustomGroups.ROLE_ADMIN) ?
 					OCA.CustomGroups.ROLE_MEMBER :

--- a/js/templates/membersList.handlebars
+++ b/js/templates/membersList.handlebars
@@ -1,6 +1,6 @@
 <div class="header">
 </div>
-<table class="grid">
+<table class="grid hidden">
 	<thead>
 		<th></th>
 		<th>Member</th>
@@ -10,4 +10,4 @@
 	<tbody class="group-member-list">
 	</tbody>
 </table>
-<div class="loading hidden" style="height: 50px"></div>
+<div class="loading loading-list" style="height: 50px"></div>

--- a/js/templates/membersListItem.handlebars
+++ b/js/templates/membersListItem.handlebars
@@ -4,6 +4,7 @@
 	<td><span class="role-display-name">{{roleDisplayName}}</span>
 	{{#if canAdmin}}
 	<a href="#" class="action-change-member-role icon icon-rename" title="{{changeMemberRoleLabel}}"></a>
+	<span class="loading icon-loading-small hidden"></span>
 	{{/if}}
 	</td>
 	<td>{{#if canAdmin}}<a href="#" class="action action-delete-member" title="{{deleteLabel}}"><span class="icon icon-delete"></span><span class="hidden-visually">{{deleteMemberLabel}}</span></a>{{/if}}</td>

--- a/tests/js/MembersViewSpec.js
+++ b/tests/js/MembersViewSpec.js
@@ -221,10 +221,12 @@ describe('MembersView test', function() {
 	});
 
 	describe('actions', function() {
+		var saveStub;
 		var confirmStub;
 		var currentUserModel;
 
 		beforeEach(function() {
+			saveStub = sinon.stub(OCA.CustomGroups.MemberModel.prototype, 'save');
 			view.render();
 			confirmStub = sinon.stub(OC.dialogs, 'confirm');
 			currentUserModel = collection.add({
@@ -243,6 +245,7 @@ describe('MembersView test', function() {
 		});
 		afterEach(function() {
 			confirmStub.restore();
+			saveStub.restore();
 		});
 
 		describe('leaving group', function() {
@@ -305,19 +308,33 @@ describe('MembersView test', function() {
 
 			it('switches role when clicking change role', function() {
 				view.$('.group-member:eq(1) .action-change-member-role').click();
-				expect(anotherAdmin.get('role')).toEqual(OCA.CustomGroups.ROLE_MEMBER);
+
+				expect(saveStub.calledOnce).toEqual(true);
+				expect(saveStub.calledOn(anotherAdmin)).toEqual(true);
+
+				expect(saveStub.calledWith({role: OCA.CustomGroups.ROLE_MEMBER}));
+				saveStub.yieldTo('success');
+				saveStub.reset();
 
 				view.$('.group-member:eq(2) .action-change-member-role').click();
-				expect(anotherMember.get('role')).toEqual(OCA.CustomGroups.ROLE_ADMIN);
+
+				expect(saveStub.calledOnce).toEqual(true);
+				expect(saveStub.calledOn(anotherMember)).toEqual(true);
+				expect(saveStub.calledWith({role: OCA.CustomGroups.ROLE_ADMIN}));
+				saveStub.yieldTo('success');
 
 				expect(confirmStub.notCalled).toEqual(true);
 			});
 			it('asks for confirmation before removing own admin powers', function() {
 				view.$('.group-member:eq(0) .action-change-member-role').click();
+				
+				expect(saveStub.notCalled).toEqual(true);
 				confirmStub.yield(true);
 				expect(confirmStub.calledOnce).toEqual(true);
 
-				expect(currentUserModel.get('role')).toEqual(OCA.CustomGroups.ROLE_MEMBER);
+				expect(saveStub.calledOnce).toEqual(true);
+				expect(saveStub.calledOn(collection.at(0))).toEqual(true);
+				expect(saveStub.calledWith({role: OCA.CustomGroups.ROLE_MEMBER}));
 			});
 			it('does not remove admin role if aborted', function() {
 				view.$('.group-member:eq(0) .action-change-member-role').click();
@@ -337,12 +354,12 @@ describe('MembersView test', function() {
 
 			collection.fetch();
 
-			expect(view.$('.loading').hasClass('hidden')).toEqual(false);
+			expect(view.$('.loading-list').hasClass('hidden')).toEqual(false);
 
 			expect(collection.sync.calledOnce).toEqual(true);
 			collection.sync.yieldTo('success');
 
-			expect(view.$('.loading').hasClass('hidden')).toEqual(true);
+			expect(view.$('.loading-list').hasClass('hidden')).toEqual(true);
 		});
 	});
 });

--- a/tests/js/MembersViewSpec.js
+++ b/tests/js/MembersViewSpec.js
@@ -307,7 +307,9 @@ describe('MembersView test', function() {
 			});
 
 			it('switches role when clicking change role', function() {
+				expect(view.$('.group-member:eq(1) .icon-rename+.loading').hasClass('hidden')).toEqual(true);
 				view.$('.group-member:eq(1) .action-change-member-role').click();
+				expect(view.$('.group-member:eq(1) .icon-rename+.loading').hasClass('hidden')).toEqual(false);
 
 				expect(saveStub.calledOnce).toEqual(true);
 				expect(saveStub.calledOn(anotherAdmin)).toEqual(true);
@@ -324,13 +326,18 @@ describe('MembersView test', function() {
 				saveStub.yieldTo('success');
 
 				expect(confirmStub.notCalled).toEqual(true);
+
 			});
 			it('asks for confirmation before removing own admin powers', function() {
 				view.$('.group-member:eq(0) .action-change-member-role').click();
+
+				expect(view.$('.group-member:eq(0) .icon-rename+.loading').hasClass('hidden')).toEqual(true);
 				
 				expect(saveStub.notCalled).toEqual(true);
 				confirmStub.yield(true);
 				expect(confirmStub.calledOnce).toEqual(true);
+
+				expect(view.$('.group-member:eq(0) .icon-rename+.loading').hasClass('hidden')).toEqual(false);
 
 				expect(saveStub.calledOnce).toEqual(true);
 				expect(saveStub.calledOn(collection.at(0))).toEqual(true);


### PR DESCRIPTION
Spinner for autocomplete now appears when loading autocomplete list or
adding member.
Spinner for list appears when loading list only.
New spinner appears when toggling role.
Tooltip now properly removed when toggling role

For https://github.com/owncloud/customgroups/issues/33#issuecomment-324007120