### PR TITLE
Use event names with namespace

### DIFF
--- a/lib/Dav/GroupMembershipCollection.php
+++ b/lib/Dav/GroupMembershipCollection.php
@@ -100,7 +100,7 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 		$this->groupsHandler->deleteGroup($groupId);
 
 		$event = new GenericEvent(null, ['groupName' => $this->groupInfo['display_name']]);
-		$this->dispatcher->dispatch('deleteGroup', $event);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::deleteGroup', $event);
 	}
 
 	/**
@@ -190,7 +190,7 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 		$this->helper->notifyUser($userId, $this->groupInfo);
 
 		$event = new GenericEvent(null, ['groupName' => $this->groupInfo['display_name'], 'user' => $userId]);
-		$this->dispatcher->dispatch('addUserToGroup', $event);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::addUserToGroup', $event);
 	}
 
 	/**
@@ -280,7 +280,7 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 
 		$event = new GenericEvent(null, ['oldGroupName' => $this->groupInfo['display_name'],
 			'newGroupName' => $displayName]);
-		$this->dispatcher->dispatch('updateGroupName', $event);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::updateGroupName', $event);
 
 		$result = $this->groupsHandler->updateGroup(
 			$this->groupInfo['group_id'],

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -144,7 +144,7 @@ class GroupsCollection implements IExtendedCollection {
 		$this->groupsHandler->addToGroup($this->helper->getUserId(), $groupId, true);
 
 		$event = new GenericEvent(null, ['groupName' => $name, 'user' => $this->helper->getUserId()]);
-		$this->dispatcher->dispatch('addGroupAndUser', $event);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::addGroupAndUser', $event);
 	}
 
 	/**

--- a/lib/Dav/MembershipNode.php
+++ b/lib/Dav/MembershipNode.php
@@ -139,8 +139,8 @@ class MembershipNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 			$this->helper->notifyUserRemoved($userId, $this->groupInfo, $this->memberInfo);
 		}
 
-		$event = new GenericEvent(null, ['user' => $currentUserId, 'groupName' => $this->groupInfo['display_name']]);
-		$this->dispatcher->dispatch('leaveGroup', $event);
+		$event = new GenericEvent(null, ['user_displayName' => $userId, 'group_displayName' => $this->groupInfo['display_name']]);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::removeUserFromGroup', $event);
 	}
 
 	/**

--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -322,7 +322,7 @@ class MembershipHelper {
 			$roleName = "Group owner";
 		}
 		$event = new GenericEvent(null, ['user' => $targetUserId, 'groupName' => $groupInfo['display_name'], 'roleNumber' => $memberInfo['role'], 'roleDisaplayName' => $roleName]);
-		$this->dispatcher->dispatch('changeRoleInGroup', $event);
+		$this->dispatcher->dispatch('\OCA\CustomGroups::changeRoleInGroup', $event);
 	}
 
 	/**
@@ -344,9 +344,6 @@ class MembershipHelper {
 			->setUser($targetUserId)
 			->setLink($link);
 		$this->notificationManager->notify($notification);
-
-		$event = new GenericEvent(null, ['user_displayName' => $targetUserId, 'group_displayName' => $groupInfo['display_name']]);
-		$this->dispatcher->dispatch('removeUserFromGroup', $event);
 	}
 
 	/**

--- a/tests/unit/Dav/GroupMembershipCollectionTest.php
+++ b/tests/unit/Dav/GroupMembershipCollectionTest.php
@@ -148,14 +148,14 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 			->with(1);
 
 		$called = array();
-		\OC::$server->getEventDispatcher()->addListener('deleteGroup', function ($event) use (&$called) {
-			$called[] = 'deleteGroup';
+		\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::deleteGroup', function ($event) use (&$called) {
+			$called[] = '\OCA\CustomGroups::deleteGroup';
 			array_push($called, $event);
 		});
 
 		$this->node->delete();
 
-		$this->assertSame('deleteGroup', $called[0]);
+		$this->assertSame('\OCA\CustomGroups::deleteGroup', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
 	}
@@ -221,6 +221,11 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 			->willReturn(true);
 
 		if ($called) {
+			$calledEvent = array();
+			\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::updateGroupName', function ($event) use (&$calledEvent){
+				$calledEvent[] = '\OCA\CustomGroups::updateGroupName';
+				array_push($calledEvent, $event);
+			});
 			$this->handler->expects($this->at(1))
 				->method('updateGroup')
 				->with(1, 'group1', 'Group Renamed')
@@ -236,6 +241,10 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 		$propPatch->commit();
 		$this->assertEmpty($propPatch->getRemainingMutations());
 		$result = $propPatch->getResult();
+		if (isset($calledEvent)) {
+			$this->assertSame('\OCA\CustomGroups::updateGroupName', $calledEvent[0]);
+			$this->assertTrue($calledEvent[1] instanceof GenericEvent);
+		}
 		$this->assertEquals($statusCode, $result[GroupMembershipCollection::PROPERTY_DISPLAY_NAME]);
 	}
 
@@ -293,14 +302,14 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 			);
 
 		$called = array();
-		\OC::$server->getEventDispatcher()->addListener('addUserToGroup', function ($event) use (&$called) {
-			$called[] = 'addUserToGroup';
+		\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::addUserToGroup', function ($event) use (&$called) {
+			$called[] = '\OCA\CustomGroups::addUserToGroup';
 			array_push($called, $event);
 		});
 
 		$this->node->createFile(self::NODE_USER);
 
-		$this->assertSame('addUserToGroup', $called[0]);
+		$this->assertSame('\OCA\CustomGroups::addUserToGroup', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
 		$this->assertArrayHasKey('user',$called[1]);

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -207,8 +207,8 @@ class GroupsCollectionTest extends \Test\TestCase {
 			->with('user1', 1, true);
 
 		$called = array();
-		\OC::$server->getEventDispatcher()->addListener('addGroupAndUser', function ($event) use (&$called) {
-			$called[] = 'addGroupAndUser';
+		\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::addGroupAndUser', function ($event) use (&$called) {
+			$called[] = '\OCA\CustomGroups::addGroupAndUser';
 			array_push($called, $event);
 		});
 
@@ -217,7 +217,7 @@ class GroupsCollectionTest extends \Test\TestCase {
 		]);
 		$this->collection->createExtendedCollection('group1', $mkCol);
 
-		$this->assertSame('addGroupAndUser', $called[0]);
+		$this->assertSame('\OCA\CustomGroups::addGroupAndUser', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
 		$this->assertArrayHasKey('user', $called[1]);

--- a/tests/unit/Dav/MembershipNodeTest.php
+++ b/tests/unit/Dav/MembershipNodeTest.php
@@ -33,6 +33,7 @@ use OCA\CustomGroups\Search;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
 use OCP\IConfig;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class MembershipNodeTest
@@ -154,7 +155,18 @@ class MembershipNodeTest extends \Test\TestCase {
 				['group_id' => 1, 'user_id' => self::NODE_USER, 'role' => CustomGroupsDatabaseHandler::ROLE_ADMIN]
 			);
 
+		$called = array();
+		\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::removeUserFromGroup', function ($event) use (&$called) {
+			$called[] = '\OCA\CustomGroups::removeUserFromGroup';
+			array_push($called, $event);
+		});
+
 		$this->node->delete();
+
+		$this->assertSame('\OCA\CustomGroups::removeUserFromGroup', $called[0]);
+		$this->assertTrue($called[1] instanceof GenericEvent);
+		$this->assertArrayHasKey('user_displayName', $called[1]);
+		$this->assertArrayHasKey('group_displayName',$called[1]);
 	}
 
 	/**

--- a/tests/unit/Service/MembershipHelperTest.php
+++ b/tests/unit/Service/MembershipHelperTest.php
@@ -463,21 +463,10 @@ class MembershipHelperTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
-		$called = array();
-		\OC::$server->getEventDispatcher()->addListener('removeUserFromGroup', function ($event) use (&$called) {
-			$called[] = 'removeUserFromGroup';
-			array_push($called, $event);
-		});
-
 		$this->helper->notifyUserRemoved(
 			'anotheruser',
 			['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One']
 		);
-
-		$this->assertSame('removeUserFromGroup', $called[0]);
-		$this->assertTrue($called[1] instanceof GenericEvent);
-		$this->assertArrayHasKey('user_displayName', $called[1]);
-		$this->assertArrayHasKey('group_displayName',$called[1]);
 	}
 
 	public function testNotifyUserRoleChange() {
@@ -500,11 +489,19 @@ class MembershipHelperTest extends \Test\TestCase {
 			->method('notify')
 			->with($notification);
 
+		$called = array();
+		\OC::$server->getEventDispatcher()->addListener('\OCA\CustomGroups::changeRoleInGroup', function ($event) use (&$called) {
+			$called[] = '\OCA\CustomGroups::changeRoleInGroup';
+			array_push($called, $event);
+		});
 		$this->helper->notifyUserRoleChange(
 			'anotheruser',
 			['group_id' => 1, 'uri' => 'group1', 'display_name' => 'Group One'],
 			['group_id' => 1, 'role' => Roles::BACKEND_ROLE_MEMBER]
 		);
+
+		$this->assertSame('\OCA\CustomGroups::changeRoleInGroup', $called[0]);
+		$this->assertTrue($called[1] instanceof GenericEvent);
 	}
 
 	public function canCreateRolesProvider() {


### PR DESCRIPTION
Use namespace along with event names.
This will help to identify who triggered
the event. More readability.

Signed-off-by: Sujith H <sharidasan@owncloud.com>