### PR TITLE
Use IUserManager::find() when searching for members

### DIFF
--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -223,13 +223,10 @@ class MembershipHelper {
 	 * Return the user ids of the members in the given group matching the given pattern
 	 *
 	 * @param int $groupId numeric group id
-	 * @param string $pattern pattern
 	 * @return array array of user ids as keys and true as value
 	 */
-	private function getGroupMemberUserIds($groupId, $pattern) {
-		$search = new Search($pattern);
-
-		$foundMembers = $this->groupsHandler->getGroupMembers($groupId, $search);
+	private function getGroupMemberUserIds($groupId) {
+		$foundMembers = $this->groupsHandler->getGroupMembers($groupId);
 		$existingMembers = [];
 		foreach ($foundMembers as $foundMember) {
 			$existingMembers[$foundMember['user_id']] = true;
@@ -248,7 +245,7 @@ class MembershipHelper {
 	 * @return IUser[] results
 	 */
 	public function searchForNewMembers($groupId, $pattern, $limit = 200) {
-		$existingMembers = $this->getGroupMemberUserIds($groupId, $pattern);
+		$existingMembers = $this->getGroupMemberUserIds($groupId);
 
 		$totalResults = [];
 		$totalResultCount = 0;
@@ -257,7 +254,7 @@ class MembershipHelper {
 		$internalOffset = 0;
 		// loop until the $totalResults reaches $limit size or no more results exist
 		do {
-			$results = $this->userManager->searchDisplayName($pattern, $internalLimit, $internalOffset);
+			$results = $this->userManager->find($pattern, $internalLimit, $internalOffset);
 			foreach ($results as $result) {
 				if ($totalResultCount >= $limit) {
 					break;

--- a/tests/unit/Service/MembershipHelperTest.php
+++ b/tests/unit/Service/MembershipHelperTest.php
@@ -266,7 +266,7 @@ class MembershipHelperTest extends \Test\TestCase {
 		
 		$this->handler->expects($this->once())
 			->method('getGroupMembers')
-			->with(1, $search)
+			->with(1)
 			->willReturn([
 				['user_id' => 'user1'],
 				['user_id' => 'user2'],
@@ -286,7 +286,7 @@ class MembershipHelperTest extends \Test\TestCase {
 		$user4->method('getDisplayName')->willReturn('User Four');
 
 		$this->userManager->expects($this->once())
-			->method('searchDisplayName')
+			->method('find')
 			->with('us', 150, 0)
 			->willReturn([$user1, $user2, $user3, $user4]);
 		$results = $this->helper->searchForNewMembers(1, 'us', 150);
@@ -310,7 +310,7 @@ class MembershipHelperTest extends \Test\TestCase {
 		
 		$this->handler->expects($this->once())
 			->method('getGroupMembers')
-			->with(1, $search)
+			->with(1)
 			->willReturn([
 				['user_id' => 'user15'],
 				['user_id' => 'user16'],
@@ -320,11 +320,11 @@ class MembershipHelperTest extends \Test\TestCase {
 		$usersChunk = array_chunk($users, 20);
 
 		$this->userManager->expects($this->at(0))
-			->method('searchDisplayName')
+			->method('find')
 			->with('us', 20, 0)
 			->willReturn($usersChunk[0]);
 		$this->userManager->expects($this->at(1))
-			->method('searchDisplayName')
+			->method('find')
 			->with('us', 20, 20)
 			->willReturn($usersChunk[1]);
 
@@ -355,7 +355,7 @@ class MembershipHelperTest extends \Test\TestCase {
 		
 		$this->handler->expects($this->once())
 			->method('getGroupMembers')
-			->with(1, $search)
+			->with(1)
 			->willReturn([
 				['user_id' => 'user15'],
 				['user_id' => 'user16'],
@@ -365,11 +365,11 @@ class MembershipHelperTest extends \Test\TestCase {
 		$usersChunk = array_chunk($users, 20);
 
 		$this->userManager->expects($this->at(0))
-			->method('searchDisplayName')
+			->method('find')
 			->with('us', 20, 0)
 			->willReturn($usersChunk[0]);
 		$this->userManager->expects($this->at(1))
-			->method('searchDisplayName')
+			->method('find')
 			->with('us', 20, 20)
 			->willReturn($usersChunk[1]);
 


### PR DESCRIPTION
This makes sure that it will not only search the user id or display name
but also any search terms that might be defined for LDAP users.

Fixes https://github.com/owncloud/customgroups/issues/90
