### PR TITLE
Fix Makefile bower deps installing and signing

### DIFF
--- a/rules/deps.mk
+++ b/rules/deps.mk
@@ -65,7 +65,7 @@ $(BOWER): $(nodejs_deps)
 $(JSDOC): $(nodejs_deps)
 
 $(bower_deps): $(BOWER)
-	$(BOWER) install && touch $@
+	$(BOWER) --allow-root install && touch $@
 
 .PHONY: deps
 deps: $(composer_deps) $(bower_deps)

--- a/rules/sign.mk
+++ b/rules/sign.mk
@@ -12,11 +12,11 @@ endif
 signature_file=$(build_dir)/$(app_name)/appinfo/signature.json
 
 $(signature_file): $(build_dir)/$(app_name)
-	@if test "$(CAN_SIGN)" == "true"; then \
-		$(sign) --path "$(build_dir)/$(app_name)"; \
-	else \
-		echo "Warning: Skipping signing, either no key and certificate found in $(private_key) and $(certificate) or occ can not be found at $(occ)" >&2; \
-	fi
+ifdef CAN_SIGN
+	$(sign) --path "$(build_dir)/$(app_name)";
+else
+	echo "Warning: Skipping signing, either no key and certificate found in $(private_key) and $(certificate) or occ can not be found at $(occ)" >&2;
+endif
 
 .PHONY: sign
 sign: $(signature_file)


### PR DESCRIPTION
Encountered issues during building the app inside the dockerized build environment (based on owncloud/server:10.0.3)
- bower would not easily run as root - needed to allow root usage 
- signing failed without proper reasoning -> adjusted the signing process as it is used in other apps