### PR TITLE
Fix role check in checkIfUserIsAdminOfCustomGroup

### DIFF
--- a/tests/integration/custom_groups_features/CustomGroups.feature
+++ b/tests/integration/custom_groups_features/CustomGroups.feature
@@ -218,7 +218,7 @@ Scenario: Superadmin can do everything
 		And user "admin" renamed custom group "group0" as "renamed-group0"
 		And custom group "group0" exists with display name "renamed-group0"
 		And user "admin" changed role of "user0" to admin in custom group "group0"
-		And user "user1" is admin of custom group "group0"
+		And user "user0" is admin of custom group "group0"
 		When user "admin" removed membership of user "user1" from custom group "group0"
 		Then members of "group0" requested by user "admin" are
 					| user0 |

--- a/tests/integration/features/bootstrap/CustomGroupsContext.php
+++ b/tests/integration/features/bootstrap/CustomGroupsContext.php
@@ -231,8 +231,8 @@ class CustomGroupsContext implements Context, SnippetAcceptingContext {
 	 * @param string $customGroup
 	 */
 	public function checkIfUserIsAdminOfCustomGroup($user, $role, $customGroup){
-		$role = $this->getUserRoleInACustomGroup('admin', $user, $customGroup);
-		PHPUnit_Framework_Assert::assertEquals($role, $role);
+		$currentRole = $this->getUserRoleInACustomGroup('admin', $user, $customGroup);
+		PHPUnit_Framework_Assert::assertEquals($role, $currentRole);
 	}
 
 	/**


### PR DESCRIPTION
The test was always true. Make it actually test if the user really is admin of the group.

Then correct the test step that fails because it was checking the wrong user name being a group admin.