### PR TITLE
Fix the inconsistancy in symfony events arguments

### DIFF
--- a/lib/Dav/GroupMembershipCollection.php
+++ b/lib/Dav/GroupMembershipCollection.php
@@ -114,7 +114,9 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 		}
 		$group->delete();
 
-		$event = new GenericEvent(null, ['groupName' => $this->groupInfo['display_name']]);
+		$event = new GenericEvent(null, [
+			'groupName' => $this->groupInfo['display_name'],
+			'groupId' => $groupId]);
 		$this->dispatcher->dispatch('\OCA\CustomGroups::deleteGroup', $event);
 	}
 
@@ -209,7 +211,10 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 
 		$this->helper->notifyUser($userId, $this->groupInfo);
 
-		$event = new GenericEvent(null, ['groupName' => $this->groupInfo['display_name'], 'user' => $userId]);
+		$event = new GenericEvent(null, [
+			'groupName' => $this->groupInfo['display_name'],
+			'groupId' => $groupId,
+			'user' => $userId]);
 		$this->dispatcher->dispatch('\OCA\CustomGroups::addUserToGroup', $event);
 	}
 
@@ -298,8 +303,10 @@ class GroupMembershipCollection implements \Sabre\DAV\ICollection, \Sabre\DAV\IP
 			return 409;
 		}
 
-		$event = new GenericEvent(null, ['oldGroupName' => $this->groupInfo['display_name'],
-			'newGroupName' => $displayName]);
+		$event = new GenericEvent(null, [
+			'oldGroupName' => $this->groupInfo['display_name'],
+			'newGroupName' => $displayName,
+			'groupId' => $this->groupInfo['group_id']]);
 		$this->dispatcher->dispatch('\OCA\CustomGroups::updateGroupName', $event);
 
 		$result = $this->groupsHandler->updateGroup(

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -152,7 +152,10 @@ class GroupsCollection implements IExtendedCollection {
 		// add current user as admin
 		$this->groupsHandler->addToGroup($this->helper->getUserId(), $groupId, true);
 
-		$event = new GenericEvent(null, ['groupName' => $name, 'user' => $this->helper->getUserId()]);
+		$event = new GenericEvent(null, [
+			'groupName' => $name,
+			'groupId' => $groupId,
+			'user' => $this->helper->getUserId()]);
 		$this->dispatcher->dispatch('\OCA\CustomGroups::addGroupAndUser', $event);
 	}
 

--- a/lib/Dav/MembershipNode.php
+++ b/lib/Dav/MembershipNode.php
@@ -137,14 +137,37 @@ class MembershipNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 		if ($currentUserId !== $userId) {
 			// only notify when the removal was done by another user
 			$this->helper->notifyUserRemoved($userId, $this->groupInfo, $this->memberInfo);
+			/**
+			 * This event is deprecated. The keys of the event array are not using camel case.
+			 */
 			$event = new GenericEvent(null, ['user_displayName' => $userId, 'group_displayName' => $this->groupInfo['display_name']]);
 			$this->dispatcher->dispatch('\OCA\CustomGroups::removeUserFromGroup', $event);
+			/**
+			 * The new event which has camel case for arguments in event array.
+			 */
+			$newEvent = new GenericEvent(null, [
+				'user' => $userId,
+				'groupName' => $this->groupInfo['display_name'],
+				'groupId' => $groupId]);
+			$this->dispatcher->dispatch('customGroups.removeUserFromGroup', $newEvent);
 		}
 
 		//Send dispatcher event if the removal is self
 		if ($currentUserId === $userId) {
+			/**
+			 * This event is deprecated, 'user' should be used instead of 'userId'
+			 * as key for event argument
+			 */
 			$event = new GenericEvent(null, ['userId' => $userId, 'groupName' => $this->groupInfo['display_name']]);
 			$this->dispatcher->dispatch('\OCA\CustomGroups::leaveFromGroup', $event);
+			/**
+			 * From now on use this event 'customGroups.leaveFromGroup'
+			 */
+			$newEvent = new GenericEvent(null, [
+				'user' => $userId,
+				'groupName' => $this->groupInfo['display_name'],
+				'groupId' => $groupId]);
+			$this->dispatcher->dispatch('customGroups.leaveFromGroup', $newEvent);
 		}
 	}
 

--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -266,7 +266,12 @@ class MembershipHelper {
 		} elseif ($memberInfo['role'] === Roles::BACKEND_ROLE_ADMIN) {
 			$roleName = "Group owner";
 		}
-		$event = new GenericEvent(null, ['user' => $targetUserId, 'groupName' => $groupInfo['display_name'], 'roleNumber' => $memberInfo['role'], 'roleDisaplayName' => $roleName]);
+		$event = new GenericEvent(null, [
+			'user' => $targetUserId,
+			'groupName' => $groupInfo['display_name'],
+			'roleNumber' => $memberInfo['role'],
+			'roleDisaplayName' => $roleName,
+			'groupId' => $memberInfo['group_id']]);
 		$this->dispatcher->dispatch('\OCA\CustomGroups::changeRoleInGroup', $event);
 	}
 

--- a/tests/unit/Dav/GroupMembershipCollectionTest.php
+++ b/tests/unit/Dav/GroupMembershipCollectionTest.php
@@ -182,6 +182,9 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 		$this->assertSame('\OCA\CustomGroups::deleteGroup', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
+		$this->assertEquals('Group One', $called[1]->getArgument('groupName'));
+		$this->assertArrayHasKey('groupId', $called[1]);
+		$this->assertEquals(1, $called[1]->getArgument('groupId'));
 	}
 
 	/**
@@ -268,7 +271,14 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 		if (isset($calledEvent)) {
 			$this->assertSame('\OCA\CustomGroups::updateGroupName', $calledEvent[0]);
 			$this->assertTrue($calledEvent[1] instanceof GenericEvent);
+			$this->assertArrayHasKey('oldGroupName', $calledEvent[1]);
+			$this->assertEquals('Group One', $calledEvent[1]->getArgument('oldGroupName'));
+			$this->assertArrayHasKey('newGroupName', $calledEvent[1]);
+			$this->assertEquals('Group Renamed', $calledEvent[1]->getArgument('newGroupName'));
+			$this->assertArrayHasKey('groupId', $calledEvent[1]);
+			$this->assertEquals(1, $calledEvent[1]->getArgument('groupId'));
 		}
+
 		$this->assertEquals($statusCode, $result[GroupMembershipCollection::PROPERTY_DISPLAY_NAME]);
 	}
 
@@ -336,7 +346,11 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 		$this->assertSame('\OCA\CustomGroups::addUserToGroup', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
+		$this->assertEquals('Group One', $called[1]->getArgument('groupName'));
 		$this->assertArrayHasKey('user',$called[1]);
+		$this->assertEquals('nodeuser', $called[1]->getArgument('user'));
+		$this->assertArrayHasKey('groupId', $called[1]);
+		$this->assertEquals(1, $called[1]->getArgument('groupId'));
 	}
 
 	/**

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -235,6 +235,10 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->assertTrue($called[1] instanceof GenericEvent);
 		$this->assertArrayHasKey('groupName', $called[1]);
 		$this->assertArrayHasKey('user', $called[1]);
+		$this->assertArrayHasKey('groupId', $called[1]);
+		$this->assertEquals('group1', $called[1]->getArgument('groupName'));
+		$this->assertEquals('user1', $called[1]->getArgument('user'));
+		$this->assertEquals(1, $called[1]->getArgument('groupId'));
 
 		$this->assertEquals(202, $mkCol->getResult()[GroupMembershipCollection::PROPERTY_DISPLAY_NAME]);
 	}

--- a/tests/unit/Service/MembershipHelperTest.php
+++ b/tests/unit/Service/MembershipHelperTest.php
@@ -378,6 +378,14 @@ class MembershipHelperTest extends \Test\TestCase {
 
 		$this->assertSame('\OCA\CustomGroups::changeRoleInGroup', $called[0]);
 		$this->assertTrue($called[1] instanceof GenericEvent);
+		$this->assertArrayHasKey('user', $called[1]);
+		$this->assertEquals('anotheruser', $called[1]->getArgument('user'));
+		$this->assertArrayHasKey('groupName', $called[1]);
+		$this->assertEquals('Group One', $called[1]->getArgument('groupName'));
+		$this->assertArrayHasKey('roleNumber', $called[1]);
+		$this->assertEquals(0, $called[1]->getArgument('roleNumber'));
+		$this->assertArrayHasKey('roleDisaplayName', $called[1]);
+		$this->assertEquals('Member', $called[1]->getArgument('roleDisaplayName'));
 	}
 
 	public function canCreateRolesProvider() {


### PR DESCRIPTION
Fix the inconsistancy in symfony events arguments.
Also updated the tests. Tried to update the tests
which were failing. The inconsistancies fixed are:
1) usage of camel case for the argument keys passed.
2) Use only groupName across and no more groupDisplayName.
3) Instead of user_display, user is used.

Signed-off-by: Sujith H <sharidasan@owncloud.com>