### PR TITLE
Trigger CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This apps makes it possible for users to create their own custom groups and manage their members.
 It is then possible to share files or folders with these groups.
 
+Trigger CI.
+
 ## QA metrics on master branch:
 
 [![Build Status](https://travis-ci.org/owncloud/customgroups.svg?branch=master)](https://travis-ci.org/owncloud/customgroups/branches)


### PR DESCRIPTION
this is expected to fail the API acceptance tests, because the core QA tarballs now have the skeleton dir in a different place.