### PR TITLE
A group name should not be displayed urlencoded during deletion

### DIFF
--- a/js/GroupsView.js
+++ b/js/GroupsView.js
@@ -155,7 +155,7 @@
 			}
 
 			OC.dialogs.confirm(
-					t('customgroups', 'Are you sure that you want to delete the group "{groupName}" ?', {groupName: model.get('displayName')}),
+					t('customgroups', 'Are you sure that you want to delete the group "{groupName}" ?', {groupName: model.get('displayName')}, null, {escape: false}),
 					t('customgroups', 'Confirm deletion of group'),
 				function confirmCallback(confirmation) {
 					if (confirmation) {


### PR DESCRIPTION
The group name displayed while deletion of the group,
should not be urlencoded. It affects the readability of the
group name. For eaxample if the group name is lets say
"a'b", it would display improper group name.

Signed-off-by: Sujith H <sharidasan@owncloud.com>