### PR TITLE
Implement owncloud coding standard

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -161,8 +161,8 @@ services:
 
 matrix:
   include:
-    # oc code style check
-    - PHP_VERSION: 7.1
+    # owncloud-coding-standard
+    - PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 
     # js-tests

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,7 +5,9 @@ $config = new OC\CodingStandard\Config();
 $config
 	->setUsingCache(true)
 	->getFinder()
+	->exclude('build')
 	->exclude('l10n')
+	->exclude('lib/composer')
 	->exclude('vendor')
 	->exclude('vendor-bin')
 	->exclude('lib/composer')
@@ -13,4 +15,3 @@ $config
 	->in(__DIR__);
 
 return $config;
-


### PR DESCRIPTION
1) adjust ``.php_cs.dist`` to exclude more directories
2) add a coding standard job to the drone matrix
3) ``make test-php-style-fix`` to actually hack the code into shape