### PR TITLE
Add validation for group creation

### DIFF
--- a/js/GroupsView.js
+++ b/js/GroupsView.js
@@ -268,7 +268,12 @@
 						OC.Notification.showTemporary(t('customgroups', 'A group with this name already exists'));
 						return;
 					}
-					OC.Notification.showTemporary(t('customgroups', 'Could not create group'));
+					if (response.status === 422) {
+						OC.Notification.showTemporary(t('customgroups', "The group name can not be empty or start with space. The group name should at least have 2 characters"));
+					}
+					if (response.status === 403) {
+						OC.Notification.showTemporary(t('customgroups', 'Could not create group'));
+					}
 				}
 			});
 		},

--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -21,6 +21,7 @@
 
 namespace OCA\CustomGroups\Dav;
 
+use OCA\CustomGroups\Exception\ValidationException;
 use Sabre\DAV\IExtendedCollection;
 use Sabre\DAV\MkCol;
 use Sabre\DAV\Exception\NotFound;
@@ -119,6 +120,21 @@ class GroupsCollection implements IExtendedCollection {
 	public function createExtendedCollection($name, Mkcol $mkCol) {
 		if (!$this->helper->canCreateGroups()) {
 			throw new Forbidden('No permission to create groups');
+		}
+
+		/** Group name cannot be empty */
+		if (($name === '') || ($name === null)) {
+			throw new ValidationException('Can not create empty group');
+		}
+
+		/** Group name must be at least 2 character long */
+		if (\strlen($name) < 2) {
+			throw new ValidationException('The group name should be at least 2 characters long.');
+		}
+
+		/** Group name should not start with space */
+		if ($name[0] === ' ') {
+			throw new ValidationException('The group name can not start with space');
 		}
 
 		$displayName = $name;

--- a/lib/Exception/ValidationException.php
+++ b/lib/Exception/ValidationException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups\Exception;
+
+use Sabre\DAV\Exception;
+
+class ValidationException extends Exception {
+	/**
+	 * Returns the HTTP statuscode for this exception.
+	 * This happens when invalid arguments are passed for creating customgroups.
+	 *
+	 * @return int
+	 */
+	public function getHTTPCode() {
+		return 422;
+	}
+}

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -22,6 +22,7 @@ namespace OCA\CustomGroups\Tests\unit\Dav;
 
 use OCA\CustomGroups\Dav\GroupsCollection;
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
+use OCA\CustomGroups\Exception\ValidationException;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\IUser;
@@ -266,6 +267,43 @@ class GroupsCollectionTest extends \Test\TestCase {
 			GroupMembershipCollection::PROPERTY_DISPLAY_NAME => 'Group One'
 		]);
 		$this->collection->createExtendedCollection('group1', $mkCol);
+	}
+
+	public function providesTestCreateException() {
+		return [
+			['', 'empty'],
+			[null, 'empty'],
+			[' abc', 'starts with space'],
+			['a', 'only one char'],
+		];
+	}
+
+	/**
+	 * @dataProvider providesTestCreateException
+	 * @expectedException \OCA\CustomGroups\Exception\ValidationException
+	 */
+	public function testCreateGroupExceptions($groupName, $displayName) {
+		$mkCol = new MkCol([], [
+			GroupMembershipCollection::PROPERTY_DISPLAY_NAME => $displayName
+		]);
+		$this->collection->createExtendedCollection($groupName, $mkCol);
+	}
+
+	/**
+	 * Test the status code.
+	 * @dataProvider providesTestCreateException
+	 * @throws ValidationException
+	 */
+	public function testCreateGroupExceptionsStatusCode($groupName, $displayName) {
+		$mkCol = new MkCol([], [
+			GroupMembershipCollection::PROPERTY_DISPLAY_NAME => $displayName
+		]);
+
+		try {
+			$this->collection->createExtendedCollection($groupName, $mkCol);
+		} catch (ValidationException $exception) {
+			$this->assertEquals(422, $exception->getHTTPCode());
+		}
 	}
 
 	/**


### PR DESCRIPTION
While creating custom groups few
validation added. The validation include:
- group names cannot begin with space
- group name cannot be empty string or null
- minimum length for group name is 2

Signed-off-by: Sujith H <sharidasan@owncloud.com>