### PR TITLE
Add COMPOSER_BIN check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # Makefile
 
+COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
+ifndef COMPOSER_BIN
+    $(error composer is not available on your system, please install composer)
+endif
+
 OWNCLOUD_PATH=$(CURDIR)/../..
 OCC=$(OWNCLOUD_PATH)/occ
 


### PR DESCRIPTION
Related to issue https://github.com/owncloud/QA/issues/609

Update to use the current "standard" way of checking for ``COMPOSER_BIN``

These days we are everywhere expecting that `composer` is already installed on a developer or CI system.