### PR TITLE
Fix duplication of clean-deps in make files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,6 @@ help: $(help_rules)
 .PHONY: clean
 clean: clean-deps $(clean_rules)
 
-.PHONY: clean-deps
-clean-deps:
-	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
-
 .PHONY: test
 test: $(test_rules)
 

--- a/rules/deps.mk
+++ b/rules/deps.mk
@@ -28,6 +28,7 @@ clean-deps: clean-composer clean-js clean-nodejs
 .PHONY: clean-composer
 clean-composer:
 	rm -Rf $(composer_deps)/
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 .PHONY: clean-js
 clean-js:


### PR DESCRIPTION
``clean-deps`` already appears in ``rules/deps.mk`` so get it out of ``Makefile``

Otherwise there are problems reported like:
```
make
Makefile:75: warning: overriding recipe for target 'clean-deps'
rules/deps.mk:26: warning: ignoring old recipe for target 'clean-deps'
```
