### PR TITLE
Make acceptance tests run and pass

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -110,7 +110,7 @@ pipeline:
       - TEST_SERVER_URL=http://owncloud
       - PLATFORM=Linux
       - BEHAT_SUITE=${BEHAT_SUITE}
-    comands:
+    commands:
       - make test-acceptance-api
     when:
       matrix:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -14,6 +14,7 @@ default:
             adminPassword: admin
             regularUserPassword: 123456
             ocPath: apps/testing/api/v1/occ
+        - WebDavPropertiesContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/bootstrap/CustomGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/CustomGroupsContext.php
@@ -21,6 +21,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Sabre\DAV\Client as SClient;
 use Sabre\HTTP\ClientException;
 use Sabre\HTTP\ClientHttpException;
 use Sabre\HTTP\ResponseInterface;
@@ -46,6 +47,25 @@ class CustomGroupsContext implements Context {
 	 * @var array
 	 */
 	private $createdCustomGroups = [];
+
+	/**
+	 * returns a Sabre client
+	 *
+	 * @param string $user
+	 *
+	 * @return SClient
+	 */
+	public function getSabreClient($user) {
+		$settings = [
+			'baseUri' => $this->featureContext->getBaseUrl() . "/",
+			'userName' => $user,
+			'password' => $this->featureContext->getPasswordForUser($user),
+			'authType' => SClient::AUTH_BASIC
+		];
+		$client = new SClient($settings);
+		$client->addCurlSetting(CURLOPT_SSL_VERIFYPEER, false);
+		return $client;
+	}
 
 	/**
 	 * @When user :user creates a custom group called :groupName using the API
@@ -107,7 +127,7 @@ class CustomGroupsContext implements Context {
 	 * @throws ClientHttpException
 	 */
 	public function getCustomGroups($user) {
-		$client = $this->featureContext->getSabreClient($user);
+		$client = $this->getSabreClient($user);
 		$properties = [
 						'{http://owncloud.org/ns}display-name'
 					  ];
@@ -208,7 +228,7 @@ class CustomGroupsContext implements Context {
 	public function sendProppatchToCustomGroup(
 		$user, $customGroup, $properties = null
 	) {
-		$client = $this->featureContext->getSabreClient($user);
+		$client = $this->getSabreClient($user);
 		$client->setThrowExceptions(true);
 		$appPath = '/customgroups/groups/';
 		$fullUrl
@@ -239,7 +259,7 @@ class CustomGroupsContext implements Context {
 	public function sendProppatchToCustomGroupMember(
 		$userRequesting, $customGroup, $userRequested, $properties = null
 	) {
-		$client = $this->featureContext->getSabreClient($userRequesting);
+		$client = $this->getSabreClient($userRequesting);
 		$client->setThrowExceptions(true);
 		$appPath = '/customgroups/groups/';
 		$fullUrl
@@ -305,7 +325,7 @@ class CustomGroupsContext implements Context {
 	 * @return array|null
 	 */
 	public function getCustomGroupMembers($user, $group) {
-		$client = $this->featureContext->getSabreClient($user);
+		$client = $this->getSabreClient($user);
 		$client->setThrowExceptions(true);
 		$properties = [
 						'{http://owncloud.org/ns}role'
@@ -337,7 +357,7 @@ class CustomGroupsContext implements Context {
 	public function getUserRoleInACustomGroup(
 		$userRequesting, $userRequested, $group
 	) {
-		$client = $this->featureContext->getSabreClient($userRequesting);
+		$client = $this->getSabreClient($userRequesting);
 		$properties = [
 						'{http://owncloud.org/ns}role'
 					  ];
@@ -473,7 +493,7 @@ class CustomGroupsContext implements Context {
 	 * @return array|null
 	 */
 	public function getCustomGroupsOfAUser($userRequesting, $userRequested) {
-		$client = $this->featureContext->getSabreClient($userRequesting);
+		$client = $this->getSabreClient($userRequesting);
 		$client->setThrowExceptions(true);
 		$properties = [
 						'{http://owncloud.org/ns}role'


### PR DESCRIPTION
The API acceptance tests were not actually running in drone because the pipeline step had a section with `comands` spelt wrong, so the step did nothing and did not fail.

1) fix spelling of `commands:`
2) add `WebDavPropertiesContext` to `behat.yml` - this is needed because of a core refactoring in recent months
3) Add a `getSabreClient` method to `CustomGroupsContext`. That method was removed in core. Put it locally here so we can get the tests passing again, then we can refactor it away, like what was done in core.