### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -180,9 +180,6 @@ services:
 matrix:
   include:
     # oc code style check
-    - PHP_VERSION: 5.6
-      TEST_SUITE: owncloud-coding-standard
-
     - PHP_VERSION: 7.0
       TEST_SUITE: owncloud-coding-standard
 
@@ -246,18 +243,10 @@ matrix:
       NEED_SERVER: true
       NEED_INSTALL_APP: true
 
-    - PHP_VERSION: 5.6
+    - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
       DB_NAME: owncloud
       NEED_SERVER: true
       NEED_INSTALL_APP: true
@@ -296,16 +285,6 @@ matrix:
       NEED_INSTALL_APP: true
 
     #API acceptance tests
-    #PHP 5.6 with core stable10
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
-      TEST_SUITE: api-acceptance
-      BEHAT_SUITE: apiCustomGroups
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_SERVER: true
-      NEED_INSTALL_APP: true
-
     #PHP 7.0 with core stable10
     - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698