### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,7 +37,7 @@ Sharing with a Custom Group is as easy and quick as always. Just click on the sh
 	</types>
 	<use-migrations>true</use-migrations>
 	<dependencies>
-		<owncloud min-version="10.0.3" max-version="10" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<sabre>
 		<plugins>

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
     "name": "owncloud/customgroups",
     "config" : {
         "platform": {
-            "php": "5.6.37"
+            "php": "7.0.8"
         }
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.2"
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.0.8"
     },
     "extra": {
         "bamarni-bin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dca8a39696fd7fe691c7a7278f1dea55",
+    "content-hash": "8e84179b9cecc5efa1dd6adf34411920",
     "packages": [],
     "packages-dev": [
         {
@@ -53,10 +53,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6"
+        "php": ">=7.0.8"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "5.6.33"
+            "php": "7.0.8"
         }
     },
     "require": {


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
