### PR TITLE
phpunit enable failOnRisky

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,10 +2,11 @@
 <phpunit bootstrap="../../tests/bootstrap.php"
 		 strict="true"
 		 verbose="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
-		 beStrictAboutTestsThatDoNotTestAnything="true"
 		>
 
 	<testsuite name='unit'>


### PR DESCRIPTION
so that we know if the unit tests are reporting risky tests

Note: `beStrictAboutTestsThatDoNotTestAnything` is nowadays the default action of `phpunit` v6 - it reports "useless" tests. So we do not need to specify this. (We have not specified it in other apps or core - it "turned on" when we updated to PHPUnit6)