### PR TITLE
Adjust unshare acceptance test

### DIFF
--- a/tests/acceptance/features/apiCustomGroups/customGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/customGroups.feature
@@ -6,40 +6,35 @@ Feature: Custom Groups
     And using new dav path
 
   Scenario: Create a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     When user "user0" creates a custom group called "group0" using the API
     Then the HTTP status code should be "201"
     And custom group "group0" should exist
 
   Scenario: Create an already existing custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     When user "user0" creates a custom group called "group0" using the API
     Then the HTTP status code should be "405"
 
   Scenario: Delete a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" deletes a custom group called "group0" using the API
     Then the HTTP status code should be "204"
     And custom group "group0" should not exist
 
   Scenario: Rename a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     When user "user0" renames custom group "group0" as "renamed-group0" using the API
     Then custom group "group0" should exist with display name "renamed-group0"
 
   Scenario: A non-admin member cannot rename its custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     And user "user0" has made user "member1" a member of custom group "group0"
@@ -47,23 +42,20 @@ Feature: Custom Groups
     Then custom group "group0" should exist with display name "group0"
 
   Scenario: Get members of a group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     When user "user0" creates a custom group called "group0" using the API
     Then the members of "group0" requested by user "user0" should be
       | user0 |
 
   Scenario: Creator of a custom group becames admin automatically
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     When user "user0" creates a custom group called "group0" using the API
     Then user "user0" should be an admin of custom group "group0"
 
   Scenario: Creator of a custom group can add members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "member2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "member2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" makes user "member1" a member of custom group "group0" using the API
     And user "user0" makes user "member2" a member of custom group "group0" using the API
@@ -73,10 +65,9 @@ Feature: Custom Groups
       | member2 |
 
   Scenario: A non-admin member of a custom group cannot add members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "member2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "member2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has made user "member1" a member of custom group "group0"
     When user "member1" makes user "member2" a member of custom group "group0" using the API
@@ -86,19 +77,17 @@ Feature: Custom Groups
       | member1 |
 
   Scenario: A non-member of a custom group cannot list its members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "not-member" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "not-member" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" makes user "member1" a member of custom group "group0" using the API
     Then user "not-member" should not be able to get members of custom group "group0"
 
   Scenario: A custom group member can list members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "member2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "member2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" makes user "member1" a member of custom group "group0" using the API
     And user "user0" makes user "member2" a member of custom group "group0" using the API
@@ -108,9 +97,8 @@ Feature: Custom Groups
       | member2 |
 
   Scenario: A non-admin member of a custom group cannot delete a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" makes user "member1" a member of custom group "group0" using the API
     And user "member1" deletes a custom group called "group0" using the API
@@ -118,10 +106,9 @@ Feature: Custom Groups
     And custom group "group0" should exist
 
   Scenario: Creator of a custom group can remove members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "member2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "member2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has made user "member1" a member of custom group "group0"
     And user "user0" has made user "member2" a member of custom group "group0"
@@ -131,10 +118,9 @@ Feature: Custom Groups
       | member2 |
 
   Scenario: A non-admin member of a custom group cannot remove members
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
-    And user "member2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
+    And user "member2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has made user "member1" a member of custom group "group0"
     And user "user0" has made user "member2" a member of custom group "group0"
@@ -146,9 +132,8 @@ Feature: Custom Groups
       | member2 |
 
   Scenario: Group owner cannot remove self if no other admin exists in the group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has made user "member1" a member of custom group "group0"
     When user "user0" removes membership of user "user0" from custom group "group0" using the API
@@ -158,9 +143,8 @@ Feature: Custom Groups
       | member1 |
 
   Scenario: A member of a custom group can leave the custom group himself
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has made user "member1" a member of custom group "group0"
     When user "member1" removes membership of user "member1" from custom group "group0" using the API
@@ -169,9 +153,8 @@ Feature: Custom Groups
       | user0 |
 
   Scenario: A user can list his groups
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has created a custom group called "group1"
     And user "user0" has created a custom group called "group2"
@@ -184,9 +167,8 @@ Feature: Custom Groups
       | group2 |
 
   Scenario: Change role of a member of a group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     And user "user0" has made user "member1" a member of custom group "group0"
@@ -194,9 +176,8 @@ Feature: Custom Groups
     Then user "member1" should be an admin of custom group "group0"
 
   Scenario: Create a custom group and let another user as admin
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     And user "user0" has made user "member1" a member of custom group "group0"
@@ -206,10 +187,9 @@ Feature: Custom Groups
     And user "user0" should be a member of custom group "group0"
 
   Scenario: Superadmin can do everything
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "admin" has created a custom group called "group0"
     And user "admin" has created a custom group called "group1"
     And user "admin" has deleted a custom group called "group1"
@@ -227,9 +207,8 @@ Feature: Custom Groups
       | admin |
 
   Scenario: Superadmin can add a user to any custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "admin" makes user "user1" a member of custom group "group0" using the API
     Then the HTTP status code should be "201"
@@ -238,18 +217,16 @@ Feature: Custom Groups
       | user1 |
 
   Scenario: Superadmin can rename any custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "admin" renames custom group "group0" as "renamed-group0" using the API
     Then custom group "group0" should exist with display name "renamed-group0"
 
   Scenario: A member converted to group owner can do the same as group owner
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And user "user0" has created a custom group called "group1"
     And user "user0" has made user "user1" a member of custom group "group0"
@@ -268,9 +245,8 @@ Feature: Custom Groups
       | user2 |
 
   Scenario: A group owner cannot remove his own admin permissions if there is no other owner in the group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     And custom group "group0" should exist
     And user "user0" has made user "member1" a member of custom group "group0"
@@ -278,8 +254,7 @@ Feature: Custom Groups
     Then user "user0" should be an admin of custom group "group0"
 
   Scenario: A non-existing user cannot be added to a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "group0"
     When user "user0" makes user "non-existing-user" a member of custom group "group0" using the API
     Then the HTTP status code should be "412"

--- a/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
@@ -201,8 +201,9 @@ Feature: Sharing Custom Groups
     And user "user0" has shared file "/PARENT/parent.txt" with group "customgroup_sharing-group"
     And user "user0" has stored etag of element "/PARENT"
     And user "user1" has stored etag of element "/"
-    When user "user1" deletes the last share using the sharing API
-    Then the etag of element "/" of user "user1" should have changed
+    When user "user1" unshares file "parent.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the etag of element "/" of user "user1" should have changed
     And the etag of element "/PARENT" of user "user0" should not have changed
 
   Scenario: Increasing permissions is allowed for owner

--- a/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
@@ -6,8 +6,7 @@ Feature: Sharing Custom Groups
     And using new dav path
 
   Scenario: Check that skeleton is properly set
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     Then user "user0" should see the following elements
       | /FOLDER/           |
       | /PARENT/           |
@@ -20,10 +19,9 @@ Feature: Sharing Custom Groups
       | /welcome.txt       |
 
   Scenario: Creating a share with a custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
-    And user "member1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "member1" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "sharing-group"
     And user "user1" has made user "member1" a member of custom group "sharing-group"
     When user "user0" creates a share using the sharing API with settings
@@ -34,9 +32,8 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
 
   Scenario: Creating a new share with user who already received a share through their custom group
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "sharing-group"
     And user "user0" has shared file "welcome.txt" with group "customgroup_sharing-group"
     When user "user0" creates a share using the sharing API with settings
@@ -47,9 +44,9 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
 
   Scenario: Keep custom group permissions in sync
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/FOLDER"
     And user "user1" has created a custom group called "group1"
     And user "user0" has shared file "textfile0.txt" with group "customgroup_group1"
     And user "user1" has moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
@@ -75,9 +72,8 @@ Feature: Sharing Custom Groups
       | mimetype          | text/plain     |
 
   Scenario: Sharee can see the custom group share
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "group1"
     And user "user0" has shared file "textfile0.txt" with group "customgroup_group1"
     When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
@@ -86,9 +82,9 @@ Feature: Sharing Custom Groups
     And the last share_id should be included in the response
 
   Scenario: Share of folder and sub-folder to same user
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/FOLDER"
     And user "user1" has created a custom group called "group1"
     And user "user0" has shared file "/PARENT" with user "user1"
     When user "user0" shares file "/PARENT/CHILD" with group "customgroup_group1" using the sharing API
@@ -101,10 +97,9 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
 
   Scenario: Share a file by multiple channels
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
     And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "group1"
     And user "user1" has made user "user2" a member of custom group "group1"
     And user "user0" has created folder "/common"
@@ -119,11 +114,11 @@ Feature: Sharing Custom Groups
       | /common/sub/textfile0.txt |
 
   Scenario: Delete all custom group shares
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "group1"
     And user "user0" has shared file "textfile0.txt" with group "customgroup_group1"
+    And user "user1" has created folder "/FOLDER"
     And user "user1" has moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
     When user "user0" deletes the last share using the sharing API
     And user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
@@ -132,10 +127,9 @@ Feature: Sharing Custom Groups
     And the last share_id should not be included in the response
 
   Scenario: Keep user custom group shares
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "group1"
     And user "user1" has made user "user2" a member of custom group "group1"
     And user "user0" has created folder "/TMP"
@@ -161,9 +155,8 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
 
   Scenario: Sharing subfolder when parent already shared
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user1" has created a custom group called "sharing-group"
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
@@ -177,9 +170,8 @@ Feature: Sharing Custom Groups
     And as "user1" folder "/sub" should exist
 
   Scenario: Sharing subfolder when parent already shared with custom group of sharer
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "sharing-group"
     And user "user0" has created folder "/test"
     And user "user0" has created folder "/test/sub"
@@ -193,9 +185,8 @@ Feature: Sharing Custom Groups
     And as "user1" folder "/sub" should exist
 
   Scenario: Unshare from self using custom groups
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "sharing-group"
     And user "user0" has made user "user1" a member of custom group "sharing-group"
     And user "user0" has shared file "/PARENT/parent.txt" with group "customgroup_sharing-group"
@@ -207,9 +198,8 @@ Feature: Sharing Custom Groups
     And the etag of element "/PARENT" of user "user0" should not have changed
 
   Scenario: Increasing permissions is allowed for owner
-    Given as user "admin"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a custom group called "sharing-group"
     And user "user0" has made user "user1" a member of custom group "sharing-group"
     And user "user0" has shared folder "/FOLDER" with group "customgroup_sharing-group"


### PR DESCRIPTION
like was done in core PR commit https://github.com/owncloud/core/pull/36120/commits/aaf1e64f259175a8a6badc40e555b25d51701abe

And adjust test scenarios to remove unneeded `Given as user "admin"` and create users without skeleton files where possible, to speed up tests.

CI failed last night https://drone.owncloud.com/owncloud/customgroups/515/15/8 because of core changes in PR https://github.com/owncloud/core/pull/36120