### PR TITLE
App should only be shown if it is whitelisted for guest

### DIFF
--- a/tests/unit/SettingsPanelTest.php
+++ b/tests/unit/SettingsPanelTest.php
@@ -12,6 +12,11 @@ namespace OCA\CustomGroups\Tests\unit;
 
 use OCA\CustomGroups\Service\MembershipHelper;
 use OCA\CustomGroups\SettingsPanel;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
 
 /**
  * @package OCA\CustomGrouops\Tests\unit
@@ -23,15 +28,23 @@ class SettingsPanelTest extends \Test\TestCase {
 	 */
 	private $panel;
 
-	/**
-	 * @var MembershipHelper
-	 */
+	/** @var MembershipHelper | \PHPUnit\Framework\MockObject\MockObject */
+	private $helper;
+	/** @var IGroupManager | \PHPUnit\Framework\MockObject\MockObject */
+	private $groupManager;
+	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
+	private $userSession;
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	public function setUp() {
 		parent::setUp();
 		$this->helper = $this->createMock(MembershipHelper::class);
-		$this->panel = new SettingsPanel($this->helper);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->panel = new SettingsPanel($this->helper, $this->groupManager,
+			$this->userSession, $this->config);
 	}
 
 	public function testGetSection() {
@@ -56,5 +69,27 @@ class SettingsPanelTest extends \Test\TestCase {
 			->willReturn(false);
 		$templateHtml = $this->panel->getPanel()->fetchPage();
 		$this->assertContains('<div id="customgroups" class="section" data-cancreategroups="false"></div>', $templateHtml);
+	}
+
+	public function testGuestUserNotDisplayCustomGroup() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('user1');
+
+		$this->userSession->method('getUser')
+			->willReturn($user);
+		$this->config->method('getSystemValue')
+			->with('customgroups.disallowed-groups', null)
+			->willReturn(['testing','guest_app']);
+
+		$group = $this->createMock(IGroup::class);
+		$group->method('getGID')
+			->willReturn('guest_app');
+		$this->groupManager->method('get')
+			->willReturnOnConsecutiveCalls(null, $group);
+		$this->groupManager->method('isInGroup')
+			->willReturn(true);
+
+		$this->assertEquals('', $this->panel->getSectionID());
 	}
 }


### PR DESCRIPTION
Customgroups app should be shown for guest only
if the app is whitelisted by the guest app.

Signed-off-by: Sujith H <sharidasan@owncloud.com>