### PR TITLE
Deny admin access when system config is set

### DIFF
--- a/lib/Dav/RootCollection.php
+++ b/lib/Dav/RootCollection.php
@@ -22,6 +22,7 @@
 namespace OCA\CustomGroups\Dav;
 
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
+use OCP\IConfig;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\SimpleCollection;
@@ -33,27 +34,30 @@ use OCP\IGroupManager;
  */
 class RootCollection extends SimpleCollection {
 	/**
-	 * Constructor
+	 * RootCollection constructor.
 	 *
-	 * @param IGroupManager $groupManager group manager
+	 * @param IGroupManager $groupManager
 	 * @param CustomGroupsDatabaseHandler $groupsHandler groups database handler
 	 * @param MembershipHelper $helper membership helper
+	 * @param IConfig $config
 	 */
 	public function __construct(
 		IGroupManager $groupManager,
 		CustomGroupsDatabaseHandler $groupsHandler,
-		MembershipHelper $helper
+		MembershipHelper $helper, IConfig $config
 	) {
 		$children = [
 			new GroupsCollection(
 				$groupManager,
 				$groupsHandler,
-				$helper
+				$helper,
+				$config
 			),
 			new UsersCollection(
 				$groupManager,
 				$groupsHandler,
-				$helper
+				$helper,
+				$config
 			),
 		];
 		parent::__construct('customgroups', $children);

--- a/lib/Dav/UsersCollection.php
+++ b/lib/Dav/UsersCollection.php
@@ -21,6 +21,7 @@
 
 namespace OCA\CustomGroups\Dav;
 
+use OCP\IConfig;
 use Sabre\DAV\ICollection;
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use Sabre\DAV\Exception\NotFound;
@@ -48,25 +49,31 @@ class UsersCollection implements ICollection {
 	 */
 	private $helper;
 
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * @var IGroupManager
 	 */
 	private $groupManager;
 
 	/**
-	 * Constructor
+	 * UsersCollection constructor.
 	 *
+	 * @param IGroupManager $groupManager
 	 * @param CustomGroupsDatabaseHandler $groupsHandler custom groups handler
 	 * @param MembershipHelper $helper
+	 * @param IConfig $config
 	 */
 	public function __construct(
 		IGroupManager $groupManager,
 		CustomGroupsDatabaseHandler $groupsHandler,
-		MembershipHelper $helper
+		MembershipHelper $helper, IConfig $config
 	) {
 		$this->groupManager = $groupManager;
 		$this->groupsHandler = $groupsHandler;
 		$this->helper = $helper;
+		$this->config = $config;
 	}
 
 	/**
@@ -105,6 +112,7 @@ class UsersCollection implements ICollection {
 				$this->groupManager,
 				$this->groupsHandler,
 				$this->helper,
+				$this->config,
 				$name
 			);
 		}

--- a/lib/Service/MembershipHelper.php
+++ b/lib/Service/MembershipHelper.php
@@ -170,11 +170,26 @@ class MembershipHelper {
 	 * @return boolean true if the user can administrate, false otherwise
 	 */
 	public function isUserAdmin($groupId) {
-		// ownCloud admin is always admin of any custom group
-		if ($this->isUserSuperAdmin()) {
+		$isCurrentUserAdmin = $this->isUserSuperAdmin();
+		$memberInfo = $this->getUserMemberInfo($groupId);
+		if ($isCurrentUserAdmin) {
+			$denyAdminAccessAll = $this->config->getSystemValue('customgroups.disallow-admin-access-all', false);
+			/**
+			 * If system config customgroups.disallow-admin-access-all is set to true
+			 * then ownCloud admin is denied from the groups which it is not the
+			 * owner of or member of. It's also denied from the display name and editing members
+			 * of the group which its not not allowed to.
+			 */
+			if ($denyAdminAccessAll) {
+				return ($memberInfo !== null && $memberInfo['role']);
+			}
+			/**
+			 * If customgroups.disallow-admin-access-all is not set then ownCloud admin
+			 * has access to all (which is default behaviour)
+			 */
 			return true;
 		}
-		$memberInfo = $this->getUserMemberInfo($groupId);
+
 		return ($memberInfo !== null && $memberInfo['role']);
 	}
 

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -106,7 +106,8 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->collection = new GroupsCollection(
 			$this->createMock(IGroupManager::class),
 			$this->handler,
-			$this->helper
+			$this->helper,
+			$this->config
 		);
 	}
 
@@ -157,8 +158,11 @@ class GroupsCollectionTest extends \Test\TestCase {
 			$this->createMock(IGroupManager::class),
 			$this->handler,
 			$this->helper,
+			$this->config,
 			'user1'
 		);
+		$this->config->method('getSystemValue')
+			->willReturn(false);
 		$this->handler->expects($this->never())->method('getGroups');
 		$this->handler->expects($this->at(0))
 			->method('getUserMemberships')
@@ -184,6 +188,7 @@ class GroupsCollectionTest extends \Test\TestCase {
 			$this->createMock(IGroupManager::class),
 			$this->handler,
 			$this->helper,
+			$this->config,
 			'user1'
 		);
 		$this->handler->expects($this->never())->method('getGroups');
@@ -320,7 +325,8 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$this->collection = new GroupsCollection(
 			$this->createMock(IGroupManager::class),
 			$this->handler,
-			$helper
+			$helper,
+			$this->config
 		);
 
 		$this->handler->expects($this->never())

--- a/tests/unit/Dav/RootCollectionTest.php
+++ b/tests/unit/Dav/RootCollectionTest.php
@@ -25,6 +25,7 @@ use OCA\CustomGroups\Dav\UsersCollection;
 use OCA\CustomGroups\Dav\GroupsCollection;
 use OCA\CustomGroups\CustomGroupsDatabaseHandler;
 use OCA\CustomGroups\Service\MembershipHelper;
+use OCP\IConfig;
 use OCP\IGroupManager;
 
 /**
@@ -37,11 +38,13 @@ class RootCollectionTest extends \Test\TestCase {
 		parent::setUp();
 		$handler = $this->createMock(CustomGroupsDatabaseHandler::class);
 		$helper = $this->createMock(MembershipHelper::class);
+		$config = $this->createMock(IConfig::class);
 
 		$this->collection = new RootCollection(
 			$this->createMock(IGroupManager::class),
 			$handler,
-			$helper
+			$helper,
+			$config
 		);
 	}
 

--- a/tests/unit/Dav/UsersCollectionTest.php
+++ b/tests/unit/Dav/UsersCollectionTest.php
@@ -70,6 +70,9 @@ class UsersCollectionTest extends \Test\TestCase {
 	 */
 	private $userSession;
 
+	/** @var IConfig */
+	private $config;
+
 	public function setUp() {
 		parent::setUp();
 		$this->handler = $this->createMock(CustomGroupsDatabaseHandler::class);
@@ -82,6 +85,8 @@ class UsersCollectionTest extends \Test\TestCase {
 		$user->method('getUID')->willReturn(self::USER);
 		$this->userSession->method('getUser')->willReturn($user);
 
+		$this->config = $this->createMock(IConfig::class);
+
 		$this->helper = new MembershipHelper(
 			$this->handler,
 			$this->userSession,
@@ -89,13 +94,14 @@ class UsersCollectionTest extends \Test\TestCase {
 			$this->groupManager,
 			$this->createMock(IManager::class),
 			$this->createMock(IURLGenerator::class),
-			$this->createMock(IConfig::class)
+			$this->config
 		);
 
 		$this->collection = new UsersCollection(
 			$this->createMock(IGroupManager::class),
 			$this->handler,
-			$this->helper
+			$this->helper,
+			$this->config
 		);
 	}
 

--- a/tests/unit/Service/MembershipHelperTest.php
+++ b/tests/unit/Service/MembershipHelperTest.php
@@ -173,6 +173,9 @@ class MembershipHelperTest extends \Test\TestCase {
 	 * @dataProvider isUserAdminDataProvider
 	 */
 	public function testIsUserAdmin($isSuperAdmin, $memberInfo, $expectedResult) {
+		$this->config->method('getSystemValue')
+			->with('customgroups.disallow-admin-access-all', false)
+			->willReturn(false);
 		$this->groupManager->expects($this->once())
 			->method('isAdmin')
 			->with(self::CURRENT_USER)
@@ -184,6 +187,19 @@ class MembershipHelperTest extends \Test\TestCase {
 			->willReturn($memberInfo);
 
 		$this->assertEquals($expectedResult, $this->helper->isUserAdmin('group1'));
+	}
+
+	public function testDenyAdminAccess() {
+		$this->config->method('getSystemValue')
+			->with('customgroups.disallow-admin-access-all', false)
+			->willReturn(true);
+		$this->groupManager->method('isAdmin')
+			->with(self::CURRENT_USER)
+			->willReturn(true);
+		$this->handler->method('getGroup')
+			->with('group1')
+			->willReturn(['role' => CustomGroupsDatabaseHandler::ROLE_MEMBER, 'display_name' => 'group1']);
+		$this->assertFalse($this->helper->isUserAdmin('group1'));
 	}
 
 	public function isUserMemberDataProvider() {


### PR DESCRIPTION
Deny admin access when system config is set
by the administrator. This will make admin
user behave as regular user for the custom groups.

Signed-off-by: Sujith H <sharidasan@owncloud.com>