### PR TITLE
Revert "test against daily server only"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,9 +45,6 @@ config = {
 			'suites': [
 				'apiCustomGroups'
 			],
-			'servers': [
-				'daily-master-qa'
-			],
 		},
 	}
 }


### PR DESCRIPTION
This reverts commit 81d85f3642f326efa545f7d2c2717324b5352211.

Fixes issue #309 

core `latest` is not 10.4.0

Note: removing these lines from `.drone.star` means that drone will now default to running the acceptance tests against both master and latest core.