### PR TITLE
[Tests-Only] Fix unit tests related to core issue 37358 and core PR 37103

### DIFF
--- a/tests/unit/Dav/GroupMembershipCollectionTest.php
+++ b/tests/unit/Dav/GroupMembershipCollectionTest.php
@@ -107,9 +107,9 @@ class GroupMembershipCollectionTest extends \Test\TestCase {
 		$this->nodeUser->method('getUID')->willReturn(self::NODE_USER);
 		$this->userManager->method('get')->will(
 			$this->returnValueMap([
-				[self::NODE_USER, $this->nodeUser],
-				[\strtoupper(self::NODE_USER), $this->nodeUser],
-				[self::CURRENT_USER, $this->currentUser],
+				[self::NODE_USER, false, $this->nodeUser],
+				[\strtoupper(self::NODE_USER), false, $this->nodeUser],
+				[self::CURRENT_USER, false, $this->currentUser],
 			]));
 
 		$this->config = $this->createMock(IConfig::class);


### PR DESCRIPTION
Part of issue https://github.com/owncloud/core/issues/37358

The signature of core `lib/private/User/Manager.php` `get()` changed to have a new 2nd parameter.
See core PR https://github.com/owncloud/core/pull/37103

Adjust unit tests so that the mocking of userManager matches the way that phpunit sees the calls. Even though the new parameter is optional (has a default value), phpunit sees the call happening with the parameter having been set to its default value `false`