### PR TITLE
[Tests-Only] Remove file_parent from tests

### DIFF
--- a/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
@@ -67,7 +67,6 @@ Feature: Sharing Custom Groups
       | mail_send         | 0              |
       | uid_owner         | Alice          |
       | storage_id        | home::Alice    |
-      | file_parent       | A_NUMBER       |
       | displayname_owner | Alice Hansen   |
       | mimetype          | text/plain     |
 


### PR DESCRIPTION
This was changed in core PR https://github.com/owncloud/core/pull/37629 issue https://github.com/owncloud/ocis-reva/issues/326

We decided to no longer test this attribute, see the PR and issue for discussion.