### PR TITLE
Respect sharing autocompletion personal setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - XXXX-XX-XX
 
-
+- Respect sharing autocompletion personal setting - [#513](https://github.com/owncloud/customgroups/pull/513)
 
 ## [0.6.2] - 2021-06-23
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -214,9 +214,9 @@ class PageController extends Controller {
 				if (isset($existingMembers[$result->getUID()])) {
 					continue;
 				}
-                                
-                                // skip if user disabled autocompletion
-                                $userAutoCompleteEnabled = $this->config->getUserValue(
+								
+				// skip if user disabled autocompletion
+				$userAutoCompleteEnabled = $this->config->getUserValue(
 					$result->getUID(),
 					'files_sharing',
 					'allow_share_dialog_user_enumeration',

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -214,6 +214,17 @@ class PageController extends Controller {
 				if (isset($existingMembers[$result->getUID()])) {
 					continue;
 				}
+                                
+                                // skip if user disabled autocompletion
+                                $userAutoCompleteEnabled = $this->config->getUserValue(
+					$result->getUID(),
+					'files_sharing',
+					'allow_share_dialog_user_enumeration',
+					'yes'
+				);
+				if ($userAutoCompleteEnabled === 'no') {
+					continue;
+				}
 
 				$totalResults[] = $result;
 				$totalResultCount++;


### PR DESCRIPTION
## Description

Respect sharing autocompletion personal setting

## Related Issue

- https://github.com/owncloud/enterprise/issues/5176

## Motivation and Context

Currently, Custom Groups app does not adhere to the `Allow finding you via autocomplete in share dialog. If this is disabled the full username needs to be entered` sharing personal setting. That is, even if user explicitly opted this out in his/her personal setting page, he/she can still be added to Custom Groups by other users

## How Has This Been Tested?

1. As `admin`, enable the sharing option `Allow username autocompletion in share dialog. If this is disabled the full username needs to be entered` system-wide (it is enabled by default)
2. As normal user `user1`, disable this option in the personal settings page
3. As normal user `user2`, create a Custom Group and try to search for user `user1` in order to add this user to the group --> before the fix `user1` was still searchable, after the fix he/she is not displayed anymore

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised