### PR TITLE
[full-ci] [tests-only] Refactored inter scenarios space

### DIFF
--- a/tests/acceptance/features/apiCustomGroups/customGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/customGroups.feature
@@ -5,11 +5,13 @@ Feature: Custom Groups
     Given using OCS API version "1"
     And using new dav path
 
+
   Scenario: Create a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" creates a custom group called "group0" using the API
     Then the HTTP status code should be "201"
     And custom group "group0" should exist
+
 
   Scenario: Create an already existing custom group
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -18,12 +20,14 @@ Feature: Custom Groups
     When user "Alice" creates a custom group called "group0" using the API
     Then the HTTP status code should be "405"
 
+
   Scenario: Delete a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created a custom group called "group0"
     When user "Alice" deletes a custom group called "group0" using the API
     Then the HTTP status code should be "204"
     And custom group "group0" should not exist
+
 
   Scenario: Rename a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -32,6 +36,7 @@ Feature: Custom Groups
     When user "Alice" renames custom group "group0" as "renamed-group0" using the API
     Then the HTTP status code should be "207"
     And custom group "renamed-group0" should exist
+
 
   Scenario: A non-admin member cannot rename its custom group
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -44,16 +49,19 @@ Feature: Custom Groups
     And custom group "group0" should exist
     But custom group "renamed-group0" should not exist
 
+
   Scenario: Get members of a group
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" creates a custom group called "group0" using the API
     Then the members of "group0" requested by user "Alice" should be
       | Alice |
 
+
   Scenario: Creator of a custom group becomes admin automatically
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" creates a custom group called "group0" using the API
     Then user "Alice" should be an admin of custom group "group0"
+
 
   Scenario: Creator of a custom group can add members
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -67,6 +75,7 @@ Feature: Custom Groups
       | Brian |
       | Carol |
 
+
   Scenario: A non-admin member of a custom group cannot add members
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -79,6 +88,7 @@ Feature: Custom Groups
       | Alice |
       | Brian |
 
+
   Scenario: A non-member of a custom group cannot list its members
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -86,6 +96,7 @@ Feature: Custom Groups
     And user "Alice" has created a custom group called "group0"
     When user "Alice" makes user "Brian" a member of custom group "group0" using the API
     Then user "not-member" should not be able to get members of custom group "group0"
+
 
   Scenario: A custom group member can list members
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -99,6 +110,7 @@ Feature: Custom Groups
       | Brian |
       | Carol |
 
+
   Scenario: A non-admin member of a custom group cannot delete a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -107,6 +119,7 @@ Feature: Custom Groups
     And user "Brian" deletes a custom group called "group0" using the API
     Then the HTTP status code should be "403"
     And custom group "group0" should exist
+
 
   Scenario: Creator of a custom group can remove members
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -119,6 +132,7 @@ Feature: Custom Groups
     Then the members of "group0" requested by user "Alice" should be
       | Alice |
       | Carol |
+
 
   Scenario: A non-admin member of a custom group cannot remove members
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -134,6 +148,7 @@ Feature: Custom Groups
       | Brian |
       | Carol |
 
+
   Scenario: Group owner cannot remove self if no other admin exists in the group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -145,6 +160,7 @@ Feature: Custom Groups
       | Alice |
       | Brian |
 
+
   Scenario: A member of a custom group can leave the custom group himself
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -154,6 +170,7 @@ Feature: Custom Groups
     Then the HTTP status code should be "204"
     And the members of "group0" requested by user "Alice" should be
       | Alice |
+
 
   Scenario: A user can list his groups
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -169,6 +186,7 @@ Feature: Custom Groups
       | group1 |
       | group2 |
 
+
   Scenario: Change role of a member of a group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -178,6 +196,7 @@ Feature: Custom Groups
     When user "Alice" changes role of "Brian" to admin in custom group "group0" using the API
     Then the HTTP status code should be "207"
     And user "Brian" should be an admin of custom group "group0"
+
 
   Scenario: Create a custom group and let another user as admin
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -190,6 +209,7 @@ Feature: Custom Groups
     Then the HTTP status code should be "207"
     And user "Brian" should be an admin of custom group "group0"
     And user "Alice" should be a member of custom group "group0"
+
 
   Scenario: Superadmin can do everything
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -211,6 +231,7 @@ Feature: Custom Groups
       | Carol |
       | admin |
 
+
   Scenario: Superadmin can add a user to any custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -221,6 +242,7 @@ Feature: Custom Groups
       | Alice |
       | Brian |
 
+
   Scenario: Superadmin can rename any custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -228,6 +250,7 @@ Feature: Custom Groups
     When user "admin" renames custom group "group0" as "renamed-group0" using the API
     Then the HTTP status code should be "207"
     And custom group "renamed-group0" should exist
+
 
   Scenario: A member converted to group owner can do the same as group owner
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -250,6 +273,7 @@ Feature: Custom Groups
       | Brian |
       | Carol |
 
+
   Scenario: A group owner cannot remove his own admin permissions if there is no other owner in the group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -260,11 +284,13 @@ Feature: Custom Groups
     Then the HTTP status code should be "207"
     And user "Alice" should be an admin of custom group "group0"
 
+
   Scenario: A non-existing user cannot be added to a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created a custom group called "group0"
     When user "Alice" makes user "non-existing-user" a member of custom group "group0" using the API
     Then the HTTP status code should be "412"
+
 
   Scenario Outline: user tries to create a custom group with name having more than 64 characters or less than 2 characters
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -278,6 +304,7 @@ Feature: Custom Groups
       | a                                                                         |
       | य                                                                         |
 
+
   Scenario Outline: user tries to create a custom group with some valid names
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" creates a custom group called "<customGroup>" using the API
@@ -289,6 +316,7 @@ Feature: Custom Groups
       | समूह         |
       | ab           |
       | hello-&#$%   |
+
 
   Scenario: trying to leave an already left custom group
     Given user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiCustomGroups/shareOperationCustomGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/shareOperationCustomGroups.feature
@@ -124,6 +124,7 @@ Feature: Sharing Custom Groups
     Then the HTTP status code should be "200"
     And the downloaded content should be "some content"
 
+
   Scenario: upload a file to a shared folder as a recipient
     Given user "Alice" has shared folder "/shared" with group "customgroup_sharing-group"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/shared/textfile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
+++ b/tests/acceptance/features/apiCustomGroups/sharingCustomGroups.feature
@@ -19,6 +19,7 @@ Feature: Sharing Custom Groups
       | /textfile4.txt     |
       | /welcome.txt       |
 
+
   Scenario: Creating a share with a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "thisIsASharedFile" to "/filetoshare.txt"
@@ -35,6 +36,7 @@ Feature: Sharing Custom Groups
     And as "Brian" file "filetoshare.txt" should exist
     And as "Carol" file "filetoshare.txt" should exist
 
+
   Scenario: Creating a new share with user who already received a share through their custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -47,6 +49,7 @@ Feature: Sharing Custom Groups
       | shareType | user            |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+
 
   Scenario: Keep custom group permissions in sync
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -76,6 +79,7 @@ Feature: Sharing Custom Groups
       | displayname_owner | Alice Hansen   |
       | mimetype          | text/plain     |
 
+
   Scenario: Sharee can see the custom group share
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -86,6 +90,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the last share_id should be included in the response
+
 
   Scenario: Share of folder and sub-folder to same user
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -106,6 +111,7 @@ Feature: Sharing Custom Groups
       | /CHILD/child.txt   |
     And the HTTP status code should be "200"
 
+
   Scenario: Share a file by multiple channels
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -124,6 +130,7 @@ Feature: Sharing Custom Groups
     And user "Carol" should see the following elements
       | /common/sub/textfile0.txt |
 
+
   Scenario: Delete all custom group shares
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -137,6 +144,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the last share id should not be included in the response
+
 
   Scenario: Keep user custom group shares
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -152,6 +160,7 @@ Feature: Sharing Custom Groups
     Then user "Brian" should see the following elements
       | /myFOLDER/myTMP/ |
 
+
   Scenario: Sharing again an own file while belonging to a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "This is a test text" to "/textfile.txt"
@@ -164,6 +173,7 @@ Feature: Sharing Custom Groups
       | shareType | group                     |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+
 
   Scenario: Sharing subfolder when parent already shared
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -180,6 +190,7 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
     And as "Brian" folder "/sub" should exist
 
+
   Scenario: Sharing subfolder when parent already shared with custom group of sharer
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -194,6 +205,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And as "Brian" folder "/sub" should exist
+
 
   Scenario: Unshare from self using custom groups
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -210,6 +222,7 @@ Feature: Sharing Custom Groups
     And the etag of element "/" of user "Brian" should have changed
     And the etag of element "/PARENT" of user "Alice" should not have changed
 
+
   Scenario: Increasing permissions is allowed for owner
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/FOLDER"
@@ -222,6 +235,7 @@ Feature: Sharing Custom Groups
       | permissions | all |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+
 
   Scenario: user shares a file to a custom group and normal group with same name
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -243,6 +257,7 @@ Feature: Sharing Custom Groups
     And custom group "group1" should exist
     And group "group1" should exist
 
+
   Scenario: sharing sub-folder to a custom group when the main folder is already shared with a user
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has been created with default attributes and without skeleton files
@@ -256,6 +271,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And as "Carol" folder "/sub-folder" should exist
+
 
   Scenario: sharing sub-folder to a custom group when the main folder is already shared with a normal group
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -283,6 +299,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And as "Brian" folder "/sub-folder" should exist
+
 
   Scenario: sharing sub-folder to a normal group when the main folder is already shared with a custom group
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -322,6 +339,7 @@ Feature: Sharing Custom Groups
     And the HTTP status code should be "200"
     And as "David" folder "/foldertoshare" should exist
 
+
   Scenario: share the same file to a different user, normal group and custom group
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -344,6 +362,7 @@ Feature: Sharing Custom Groups
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And as "David" file "/filetoshare.txt" should exist
+
 
   Scenario: share the same folder to the same user through different medium
     Given user "Alice" has been created with default attributes and without skeleton files
@@ -380,6 +399,7 @@ Feature: Sharing Custom Groups
       | file_target | /foldertoshare |
       | item_type   | folder         |
     And as "Brian" folder "/foldertoshare" should exist
+
 
   Scenario: share the same file to the same user through different medium
     Given user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareExpPerm/shareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareExpPerm/shareWithExpiryDate.feature
@@ -12,6 +12,7 @@ Feature: Sharing Custom Groups
     And user "Alice" has made user "Brian" a member of custom group "sharing-group"
     And user "Alice" has created folder "/shared"
 
+
   Scenario: sharing with default expiration date enabled but not enforced for groups, user shares to custom group without specifying expireDate
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     When user "Alice" shares folder "/shared" with group "customgroup_sharing-group" using the sharing API
@@ -195,6 +196,7 @@ Feature: Sharing Custom Groups
       | yes                 | yes                 | +30 days             |
       | no                  | yes                 |                      |
 
+
   Scenario Outline: sharing with default expiration date enforced for groups, user shares to custom group with different time format
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And user "Alice" has uploaded file with content "thisIsASharedFile" to "/filetoshare.txt"
@@ -289,6 +291,7 @@ Feature: Sharing Custom Groups
       | yes     | yes     |
       | yes     | no      |
       | no      | no      |
+
 
   Scenario: sharing with default expiration date enforced for groups, user shares to custom group with past expiration date set
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"


### PR DESCRIPTION
## Description
Interspacing between two scenarios is made consistent as documented https://github.com/owncloud/docs-server/pull/697/files#diff-12a0f404a5bbbda65e50018a487cd725797106d670f4308b921d2081dc4b3516R1129-R1154:~:text=more%20relevant%20discussion.-,%3D%3D%3D%3D%20Inter%2Dscenario%20spacings,%2D%2D%2D%2D,-Commenting%20on%20lines

## Related Issue
- Part of https://github.com/owncloud/QA/issues/769
