### PR TITLE
Add Menu Icon

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -30,3 +30,26 @@ if (!\defined('PHPUNIT') && !\OC::$CLI) {
 		\OCP\Util::addStyle('customgroups', 'icon');
 	}
 }
+
+\OC::$server->getNavigationManager()->add(function () {
+    $urlGenerator = \OC::$server->getURLGenerator();
+    return [
+        // the string under which your app will be referenced in owncloud
+        'id' => 'customgroups',
+
+        // sorting weight for the navigation. The higher the number, the higher
+        // will it be listed in the navigation
+        'order' => 90,
+
+        // the route that will be shown on startup
+        'href' => $urlGenerator->linkToRoute('settings.SettingsPage.getPersonal', ['sectionid' => 'customgroups']),
+
+        // the icon that will be shown in the navigation
+        // this file needs to exist in img/
+        'icon' => $urlGenerator->imagePath('customgroups', 'app.svg'),
+
+        // the title of your application. This will be used in the
+        // navigation or on the settings page of your app
+        'name' => \OC::$server->getL10N('customgroups')->t('Groups'),
+    ];
+});


### PR DESCRIPTION
Add Groups menu icon to left upper corner menu for Custom Groups to make it easier for users to manage their custom groups.

![Screenshot 2023-06-19 at 11 53 17](https://github.com/owncloud/customgroups/assets/2477797/bad186eb-b8d5-4943-9742-e15991302a95)
