### PR TITLE
fix: prevent non-admins from retrieving all customgroups

### DIFF
--- a/lib/Dav/GroupsCollection.php
+++ b/lib/Dav/GroupsCollection.php
@@ -228,8 +228,10 @@ class GroupsCollection implements IExtendedCollection {
 		if ($this->userId !== null) {
 			$allGroups = $this->groupsHandler->getUserMemberships($this->userId, $search);
 		} else {
+			$sessionUser = \OC::$server->getUserSession()->getUser();
+			$userIsAdmin = \OC_User::isAdminUser($sessionUser->getUID());
 			$disallowAdminAccessAll = $this->config->getSystemValue('customgroups.disallow-admin-access-all', false);
-			if ($disallowAdminAccessAll) {
+			if ($disallowAdminAccessAll || !$userIsAdmin) {
 				$allGroups = $this->groupsHandler->getUserMemberships($this->helper->getUserId(), $search);
 			} else {
 				$allGroups = $this->groupsHandler->getGroups($search);

--- a/tests/unit/Dav/GroupsCollectionTest.php
+++ b/tests/unit/Dav/GroupsCollectionTest.php
@@ -36,13 +36,17 @@ use OCP\Notification\IManager;
 use OCP\IConfig;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Sabre\DAV\MkCol;
+use Test\Traits\UserTrait;
 
 /**
  * Class GroupsCollectionTest
  *
+ * @group DB
  * @package OCA\CustomGroups\Tests\Unit
  */
 class GroupsCollectionTest extends \Test\TestCase {
+	use UserTrait;
+
 	/**
 	 * @var CustomGroupsDatabaseHandler
 	 */
@@ -75,6 +79,11 @@ class GroupsCollectionTest extends \Test\TestCase {
 		$userManager = $this->createMock(IUserManager::class);
 		$groupManager = $this->createMock(IGroupManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+
+		$user = $this->createUser('user1');
+		\OC::$server->getGroupManager()->createGroup('admin');
+		self::loginAsUser("user1");
+		\OC::$server->getGroupManager()->get('admin')->addUser($user);
 
 		$this->config = $this->createMock(IConfig::class);
 		$this->config->method('getAppValue')


### PR DESCRIPTION
Fixes an issue where any user could retrieve all customgroups of an instance when querying `/remote.php/dav/customgroups/groups`. This should only be possible for admin users.

fixes https://github.com/owncloud/enterprise/issues/5873