### PR TITLE
fix: drop JavaScript function `tipsy()` in favor of botstrap tooltip

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -7,6 +7,4 @@ $(document).ready(function() {
 		}
 		OC.AppConfig.setValue('customgroups', $(this).attr('name'), value);
 	});
-
-	$('.section .icon-info').tipsy({gravity: 'w'});
 });


### PR DESCRIPTION
refs https://github.com/owncloud/core/pull/41099

can be released any time - but before 10.14 goes out ....