### PR TITLE
Fix missing where clause in inGroupByUri()

### DIFF
--- a/lib/CustomGroupsDatabaseHandler.php
+++ b/lib/CustomGroupsDatabaseHandler.php
@@ -95,7 +95,7 @@ class CustomGroupsDatabaseHandler {
 			->from('custom_group_member', 'm')
 			->from('custom_group', 'g')
 			->where($qb->expr()->eq('g.group_id', 'm.group_id'))
-			->where($qb->expr()->eq('uri', $qb->createNamedParameter($uri)))
+			->andWhere($qb->expr()->eq('uri', $qb->createNamedParameter($uri)))
 			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($uid)))
 			->execute();
 


### PR DESCRIPTION
User was reported to be in every custom-group as soon as he was in one custom-group by the inGroupByUri method.

http://sqlfiddle.com/#!17/9097f7/1

Incorrect resulting query

```sql
SELECT user_id 
FROM oc_custom_group_member m, oc_custom_group g 
WHERE uri = 'GroupFG' AND user_id = 'userE';
```

Correct/Intended query
```sql
SELECT user_id 
FROM oc_custom_group_member m, oc_custom_group g 
WHERE g.group_id = m.group_id AND uri = 'GroupFG' AND user_id = 'userE';
```

Slightly-Offtopic: This should probably be refactored in to a LEFT JOIN?
