### PR TITLE
fix: properly cleanup users upon removal

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -19,9 +19,12 @@
  *
  */
 
+use OCA\CustomGroups\Hooks;
+
 $app = new \OCA\CustomGroups\Application();
 $app->registerGroupBackend();
 $app->registerNotifier();
+$app->getContainer()->query(Hooks::class)->register();
 
 if (!\defined('PHPUNIT') && !\OC::$CLI) {
 	$pathInfo = \OC::$server->getRequest()->getPathInfo();

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Pasquale Tripodi <pasquale.tripodi@kiteworks.com>
+ * @author Ilja Neumann <ilja.neumann@kiteworks.com>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\CustomGroups;
+
+class Hooks {
+	public static function register(): void {
+		\OCP\Util::connectHook(
+			'OC_User',
+			'post_deleteUser',
+			self::class,
+			'userDelete'
+		);
+	}
+
+	public static function userDelete($params) {
+		$customGroupsDb = \OC::$server->query(CustomGroupsDatabaseHandler::class);
+		foreach ($customGroupsDb->getUserMemberships($params['uid'], null) as $customgroup) {
+			$customGroupsDb->removeFromGroup($params['uid'], $customgroup['group_id']);
+		}
+	}
+}


### PR DESCRIPTION
We are currently missing the hook for removing the user from the `oc_custom_group_member` table when performing the user delete. I do not see any reason why the user should still be listed in the custom groups view (with an X avatar).

This would solve the issue for both "normal" and guest users, as currently when navigating through the group members views a new invitation mail is going to be resent to the guest user so that he/she will regain access to resources he/she should no longer have access to.