### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,43 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: phpunit/phpunit
-    versions:
-    - "< 7, >= 6.a"
-  - dependency-name: phpunit/phpunit
-    versions:
-    - "< 8, >= 7.a"
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: karma
-    versions:
-    - 6.0.3
-    - 6.0.4
-    - 6.1.0
-    - 6.1.1
-    - 6.1.2
-    - 6.2.0
-    - 6.3.0
-    - 6.3.1
-  - dependency-name: sinon
-    versions:
-    - 10.0.0
-    - 9.2.4
-  - dependency-name: underscore
-    versions:
-    - 1.12.1
-  - dependency-name: jasmine-core
-    versions:
-    - 3.7.0
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
