### PR TITLE
test: bump Behat Mink to use the current minor release 1.13

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -6,7 +6,7 @@
     },
     "require": {
         "behat/behat": "^3.31",
-        "behat/mink": "1.7.1",
+        "behat/mink": "^1.13",
         "friends-of-behat/mink-extension": "^2.7",
         "behat/mink-selenium2-driver": "^1.5",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",


### PR DESCRIPTION
Note: `behat/mink` is only needed for webUI acceptance tests.
This repo does not have any UI acceptance tests. So it is not a good test of this version bump.
