### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 
+## [0.10.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [0.10.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [0.9.1] - 2024-04-11
 
  - [#626](https://github.com/owncloud/customgroups/pull/626) - fix: implement hooks to properly cleanup users upon complete removal
@@ -214,7 +224,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixes spinner issues - [#47](https://github.com/owncloud/customgroups/issues/47)
 
-[Unreleased]: https://github.com/owncloud/customgroups/compare/v0.9.1...master
+[Unreleased]: https://github.com/owncloud/customgroups/compare/v0.10.1..master
+[0.10.1]: https://github.com/owncloud/customgroups/compare/v0.10.0..v0.10.1
+[0.10.0]: https://github.com/owncloud/customgroups/compare/v0.9.1..v0.10.0
 [0.9.1]: https://github.com/owncloud/customgroups/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/owncloud/customgroups/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/owncloud/customgroups/compare/v0.7.2...v0.8.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ Sharing with a Custom Group is as easy and quick as always. Just click on the sh
 	<repository type="git">http://github.com/owncloud/customgroups.git</repository>
 	<licence>AGPL</licence>
 	<author>Vincent Petry</author>
-	<version>0.10.0</version>
+	<version>0.10.1</version>
 	<documentation>
     		<user>https://doc.owncloud.com/server/latest/user_manual/files/webgui/custom_groups.html</user>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/user/user_configuration.html?highlight=custom%20groups#enabling-custom-groups</admin>


### PR DESCRIPTION
Patch-level version bump (0.10.0 -> 0.10.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.