### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 
+## [0.10.2] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
 ## [0.10.1] - 2026-07-22
 
 ### Changed
@@ -224,7 +229,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixes spinner issues - [#47](https://github.com/owncloud/customgroups/issues/47)
 
-[Unreleased]: https://github.com/owncloud/customgroups/compare/v0.10.1..master
+[Unreleased]: https://github.com/owncloud/customgroups/compare/v0.10.2..master
+[0.10.2]: https://github.com/owncloud/customgroups/compare/v0.10.1..v0.10.2
 [0.10.1]: https://github.com/owncloud/customgroups/compare/v0.10.0..v0.10.1
 [0.10.0]: https://github.com/owncloud/customgroups/compare/v0.9.1..v0.10.0
 [0.9.1]: https://github.com/owncloud/customgroups/compare/v0.9.0...v0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [0.10.2] - 2026-07-22
 
 ### Changed
-- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+- Re-release to correct a build error in the previous package for the ownCloud 11.0.0 release.
 
 ## [0.10.1] - 2026-07-22
 
 ### Changed
-- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+- Re-release to correct a build error in the previous package for the ownCloud 11.0.0 release.
 
 ## [0.10.0] - 2026-06-29
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ Sharing with a Custom Group is as easy and quick as always. Just click on the sh
 	<repository type="git">http://github.com/owncloud/customgroups.git</repository>
 	<licence>AGPL</licence>
 	<author>Vincent Petry</author>
-	<version>0.10.1</version>
+	<version>0.10.2</version>
 	<documentation>
     		<user>https://doc.owncloud.com/server/latest/user_manual/files/webgui/custom_groups.html</user>
 		<admin>https://doc.owncloud.com/server/latest/admin_manual/configuration/user/user_configuration.html?highlight=custom%20groups#enabling-custom-groups</admin>


### PR DESCRIPTION
Patch-level version bump (0.10.1 -> 0.10.2) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.